### PR TITLE
Implement HMAC-SHA256

### DIFF
--- a/applet/src/main/java/crypto/CryptoApplet.java
+++ b/applet/src/main/java/crypto/CryptoApplet.java
@@ -2,17 +2,17 @@ package crypto;
 
 import javacard.framework.*;
 
-public class HMACSha256Applet extends Applet {
+public class CryptoApplet extends Applet {
     final public static byte INS_HMAC_SHA256 = 0x25;
     public static byte[] hash_buff;
 
     public static void install(byte[] bArray, short bOffset, byte bLength) {
-        new HMACSha256Applet().register();
+        new CryptoApplet().register();
         HmacSha256.init(JCSystem.makeTransientByteArray(HmacSha256.REQUIRED_BUFFER_LENGTH, JCSystem.CLEAR_ON_DESELECT));
         hash_buff = JCSystem.makeTransientByteArray((short) 128, JCSystem.CLEAR_ON_DESELECT);
     }
 
-    public HMACSha256Applet() {
+    public CryptoApplet() {
 
     }
 

--- a/applet/src/main/java/crypto/HMACSha256Applet.java
+++ b/applet/src/main/java/crypto/HMACSha256Applet.java
@@ -1,0 +1,62 @@
+package crypto;
+
+import javacard.framework.*;
+
+public class HMACSha256Applet extends Applet {
+    final public static byte INS_HMAC_SHA256 = 0x25;
+    public static byte[] hash_buff;
+
+    public static void install(byte[] bArray, short bOffset, byte bLength) {
+        new HMACSha256Applet().register();
+        HmacSha256.init(JCSystem.makeTransientByteArray(HmacSha256.REQUIRED_BUFFER_LENGTH, JCSystem.CLEAR_ON_DESELECT));
+        hash_buff = JCSystem.makeTransientByteArray((short) 128, JCSystem.CLEAR_ON_DESELECT);
+    }
+
+    public HMACSha256Applet() {
+
+    }
+
+    public void hmacSha256(APDU apdu) {
+        byte[] buffer = apdu.getBuffer();
+        apdu.setIncomingAndReceive();
+
+        // we expect a buffer with the following format:
+        //
+        // [2-byte key length] [key] [2-byte data length] [data]
+        //
+        short keyLength = Util.getShort(buffer, ISO7816.OFFSET_CDATA);
+        short keyOffset = (short) (ISO7816.OFFSET_CDATA + 2);
+        short dataLength = Util.getShort(buffer, (short) (keyOffset + keyLength));
+        short dataOffset = (short) (keyOffset + keyLength + 2);
+
+        short outLengh = HmacSha256.compute(
+                // key
+                buffer,
+                keyOffset,
+                keyLength,
+
+                // message
+                buffer,
+                dataOffset,
+                dataLength,
+
+                // mac
+                buffer,
+                ISO7816.OFFSET_CDATA);
+
+        apdu.setOutgoingAndSend(ISO7816.OFFSET_CDATA, outLengh);
+    }
+
+    public void process(APDU apdu) {
+        byte[] buffer = apdu.getBuffer();
+
+        switch (buffer[ISO7816.OFFSET_INS]) {
+            case INS_HMAC_SHA256:
+                hmacSha256(apdu);
+                break;
+            default:
+                ISOException.throwIt(ISO7816.SW_INS_NOT_SUPPORTED);
+                break;
+        }
+    }
+}

--- a/applet/src/main/java/crypto/HmacSha256.java
+++ b/applet/src/main/java/crypto/HmacSha256.java
@@ -1,0 +1,79 @@
+package crypto;
+
+import javacard.framework.ISOException;
+import javacard.framework.Util;
+import javacard.security.MessageDigest;
+
+public class HmacSha256 {
+
+    public static final short BLOCK_SIZE = 64;
+    public static final short HASH_SIZE = 32;
+
+    // When calling init, the buffer should be at least this length
+    public static final short REQUIRED_BUFFER_LENGTH = BLOCK_SIZE + HASH_SIZE;
+
+    // TODO: extract somewhere else
+    public static final short SW_HMAC_UNSUPPORTED_KEY_LENGTH = (short) 0x9c1E;
+
+    private static byte[] buffer;
+    private static MessageDigest sha256;
+
+    public static void init(byte[] tmp) {
+        sha256 = MessageDigest.getInstance(
+                MessageDigest.ALG_SHA_256,
+                false // externalAccess
+        );
+        buffer = tmp;
+    }
+
+    public static short compute(
+            byte[] key, short keyOffset, short keyLength,
+            byte[] message, short messageOffset, short messageLength,
+            byte[] mac, short macOffset) {
+
+        // Sorry, we don't support big keys :c
+        if (keyLength > BLOCK_SIZE || keyLength < 0) {
+            ISOException.throwIt(SW_HMAC_UNSUPPORTED_KEY_LENGTH);
+        }
+
+        // compute inner hash
+        for (short i = 0; i < keyLength; i++) {
+            short k = (short) (keyOffset + i);
+            buffer[i] = (byte) (key[k] ^ 0x36);
+        }
+
+        // padd inner key to the block size
+        Util.arrayFillNonAtomic(
+                buffer,
+                keyLength, // offset, after the key
+                (short) (BLOCK_SIZE - keyLength), // length, to the end of the BLOCK
+                (byte) 0x36);
+
+        sha256.reset();
+        // write inner key
+        sha256.update(buffer, (short) 0, BLOCK_SIZE);
+
+        // and then the message
+        sha256.doFinal(
+                message,
+                messageOffset,
+                messageLength,
+                buffer, // output
+                BLOCK_SIZE // output offset; the hash will be after the inner key
+        );
+
+        // compute outer key
+        for (short i = 0; i < keyLength; i++) {
+            short k = (short) (keyOffset + i);
+            buffer[i] = (byte) (key[k] ^ 0x5c);
+        }
+        // pad outer key
+        Util.arrayFillNonAtomic(buffer, keyLength, (short) (BLOCK_SIZE - keyLength), (byte) 0x5c);
+
+        sha256.reset();
+        // compute hash from the `outer key || hash`
+        sha256.doFinal(buffer, (short) 0, (short) (BLOCK_SIZE + HASH_SIZE), mac, macOffset);
+
+        return HASH_SIZE;
+    }
+}

--- a/applet/src/main/java/crypto/Utils.java
+++ b/applet/src/main/java/crypto/Utils.java
@@ -1,0 +1,46 @@
+package crypto;
+
+public class Utils {
+
+    public static byte[] parseHex(String s) {
+        final int len = s.length();
+
+        // "111" is not a valid hex encoding.
+        if (len % 2 != 0)
+            throw new IllegalArgumentException("hexBinary needs to be even-length: " + s);
+
+        byte[] out = new byte[len / 2];
+
+        for (int i = 0; i < len; i += 2) {
+            int h = hexToBin(s.charAt(i));
+            int l = hexToBin(s.charAt(i + 1));
+            if (h == -1 || l == -1)
+                throw new IllegalArgumentException("contains illegal character for hexBinary: " + s);
+
+            out[i / 2] = (byte) (h * 16 + l);
+        }
+
+        return out;
+    }
+
+    private static int hexToBin(char ch) {
+        if ('0' <= ch && ch <= '9')
+            return ch - '0';
+        if ('A' <= ch && ch <= 'F')
+            return ch - 'A' + 10;
+        if ('a' <= ch && ch <= 'f')
+            return ch - 'a' + 10;
+        return -1;
+    }
+
+    private static final char[] hexCode = "0123456789abcdef".toCharArray();
+
+    public static String toHex(byte[] data) {
+        StringBuilder r = new StringBuilder(data.length * 2);
+        for (byte b : data) {
+            r.append(hexCode[(b >> 4) & 0xF]);
+            r.append(hexCode[(b & 0xF)]);
+        }
+        return r.toString();
+    }
+}

--- a/applet/src/test/java/tests/CryptoBase.java
+++ b/applet/src/test/java/tests/CryptoBase.java
@@ -1,0 +1,45 @@
+package tests;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import com.licel.jcardsim.smartcardio.CardSimulator;
+import com.licel.jcardsim.utils.AIDUtil;
+
+import crypto.CryptoApplet;
+import javacard.framework.AID;
+
+public class CryptoBase {
+    protected CardSimulator card;
+    protected final AID aid = AIDUtil.create("F000000001");
+
+    public CryptoBase() {
+        card = new CardSimulator();
+        card.installApplet(aid, CryptoApplet.class);
+        card.selectApplet(aid);
+    }
+
+    void putShort(short a, byte[] arr, int offset) {
+        arr[offset] = (byte) ((a & 0xFF00) >> 8);
+        arr[offset + 1] = (byte) (a & 0x00FF);
+    }
+
+    @BeforeAll
+    public static void setUpClass() throws Exception {
+    }
+
+    @AfterAll
+    public static void tearDownClass() throws Exception {
+    }
+
+    @BeforeEach
+    public void setUpMethod() throws Exception {
+
+    }
+
+    @AfterEach
+    public void tearDownMethod() throws Exception {
+    }
+}

--- a/applet/src/test/java/tests/HmacSha256Test.java
+++ b/applet/src/test/java/tests/HmacSha256Test.java
@@ -1,0 +1,99 @@
+package tests;
+
+import com.licel.jcardsim.smartcardio.CardSimulator;
+import com.licel.jcardsim.utils.AIDUtil;
+import crypto.HMACSha256Applet;
+import crypto.Utils;
+import javacard.framework.AID;
+import org.junit.Assert;
+import org.junit.jupiter.api.*;
+
+import javax.smartcardio.CommandAPDU;
+import javax.smartcardio.ResponseAPDU;
+
+public class HmacSha256Test {
+    CardSimulator card;
+    final AID aid = AIDUtil.create("F000000001");
+
+    public HmacSha256Test() {
+        card = new CardSimulator();
+        card.installApplet(aid, HMACSha256Applet.class);
+        card.selectApplet(aid);
+    }
+
+    void putShort(short a, byte[] arr, int offset) {
+        arr[offset] = (byte) ((a & 0xFF00) >> 8);
+        arr[offset + 1] = (byte) (a & 0x00FF);
+    }
+
+    void testWith(byte[] key, byte[] data, String expected) {
+        byte[] apduData = new byte[2 + key.length + 2 + data.length];
+        // resulting array is...
+        // 2 byte key length
+        putShort((short) key.length, apduData, 0);
+        // then the key
+        System.arraycopy(key, 0, apduData, 2, key.length);
+        // then 2 byte data length
+        putShort((short) data.length, apduData, 2 + key.length);
+        // then data itself
+        System.arraycopy(data, 0, apduData, 2 + key.length + 2, data.length);
+
+        CommandAPDU apdu = new CommandAPDU(0x00, HMACSha256Applet.INS_HMAC_SHA256, 0x00, 0x00, apduData);
+        ResponseAPDU response = card.transmitCommand(apdu);
+        byte[] raw = response.getData();
+
+        Assert.assertEquals(expected, Utils.toHex(raw));
+    }
+
+    @BeforeAll
+    public static void setUpClass() throws Exception {
+    }
+
+    @AfterAll
+    public static void tearDownClass() throws Exception {
+    }
+
+    @BeforeEach
+    public void setUpMethod() throws Exception {
+
+    }
+
+    @AfterEach
+    public void tearDownMethod() throws Exception {
+    }
+
+    @Test
+    public void simple() {
+        testWith("key".getBytes(), "input".getBytes(),
+                "9e089ec13af881a8ac227a736c3e7c490ea3b4afca0c5f83dff6393b683a72e3");
+    }
+
+    @Test
+    public void emptyKey() {
+        testWith("".getBytes(), "input".getBytes(), "d00c6678e09a0503bdbf68009b6af1c0593fe6a5318609540fef362e7c410219");
+    }
+
+    @Test
+    public void emptyInput() {
+        testWith("key".getBytes(), "".getBytes(), "5d5d139563c95b5967b9bd9a8c9b233a9dedb45072794cd232dc1b74832607d0");
+    }
+
+    @Test
+    public void emptyEverything() {
+        testWith("".getBytes(), "".getBytes(), "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad");
+    }
+
+    @Test
+    public void bigInput() {
+        String input = "glory to ukraine".repeat(8);
+        testWith("key".getBytes(), input.getBytes(),
+                "958eff03668143bbb558f97f731d008abafa297b245ec7bedacf6260018a2e61");
+    }
+
+    @Test
+    public void bigKey() {
+        String key = "glory to ukraine".repeat(4); // 64 bytes, block size
+        testWith(key.getBytes(), "input".getBytes(),
+                "4fbaee54a85de8c6187ff1554a7bb56383d64afd8719bc1e43691dffaefe8bd4");
+    }
+}

--- a/applet/src/test/java/tests/HmacSha256Test.java
+++ b/applet/src/test/java/tests/HmacSha256Test.java
@@ -1,31 +1,14 @@
 package tests;
 
-import com.licel.jcardsim.smartcardio.CardSimulator;
-import com.licel.jcardsim.utils.AIDUtil;
-import crypto.HMACSha256Applet;
+import crypto.CryptoApplet;
 import crypto.Utils;
-import javacard.framework.AID;
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 import javax.smartcardio.CommandAPDU;
 import javax.smartcardio.ResponseAPDU;
 
-public class HmacSha256Test {
-    CardSimulator card;
-    final AID aid = AIDUtil.create("F000000001");
-
-    public HmacSha256Test() {
-        card = new CardSimulator();
-        card.installApplet(aid, HMACSha256Applet.class);
-        card.selectApplet(aid);
-    }
-
-    void putShort(short a, byte[] arr, int offset) {
-        arr[offset] = (byte) ((a & 0xFF00) >> 8);
-        arr[offset + 1] = (byte) (a & 0x00FF);
-    }
-
+public class HmacSha256Test extends CryptoBase {
     void testWith(byte[] key, byte[] data, String expected) {
         byte[] apduData = new byte[2 + key.length + 2 + data.length];
         // resulting array is...
@@ -38,28 +21,11 @@ public class HmacSha256Test {
         // then data itself
         System.arraycopy(data, 0, apduData, 2 + key.length + 2, data.length);
 
-        CommandAPDU apdu = new CommandAPDU(0x00, HMACSha256Applet.INS_HMAC_SHA256, 0x00, 0x00, apduData);
+        CommandAPDU apdu = new CommandAPDU(0x00, CryptoApplet.INS_HMAC_SHA256, 0x00, 0x00, apduData);
         ResponseAPDU response = card.transmitCommand(apdu);
         byte[] raw = response.getData();
 
         Assert.assertEquals(expected, Utils.toHex(raw));
-    }
-
-    @BeforeAll
-    public static void setUpClass() throws Exception {
-    }
-
-    @AfterAll
-    public static void tearDownClass() throws Exception {
-    }
-
-    @BeforeEach
-    public void setUpMethod() throws Exception {
-
-    }
-
-    @AfterEach
-    public void tearDownMethod() throws Exception {
     }
 
     @Test


### PR DESCRIPTION
This PR adds implementation of the hmac-sha256. My javacard device already contains sha256 primitive, so it's fairly easy to implement hmac. It's a stepping stone to implementing proper AEAD.

Right now it has a one-shot API, but in the future it should probably be extended to three calls: `init`, `update`, `doFinal`, if the associated data is to be supported.