### PR TITLE
Refactor project structure

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,8 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Set up Java version
         uses: actions/setup-java@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,20 @@
+on: [pull_request, push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+
+      - name: Set up Java version
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "11"
+
+      - name: Check
+        run: ./gradlew check
+
+      - name: Build applet
+        run: ./gradlew buildJavaCard

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: java
-jdk: oraclejdk11
-script:
-  - ./gradlew check --info
-  - ./gradlew buildJavaCard --info
-

--- a/applet/bin/test/log4j.properties
+++ b/applet/bin/test/log4j.properties
@@ -1,0 +1,8 @@
+# Root Logger Option
+log4j.rootLogger=DEBUG, console
+
+# Redirect Log Messages To Console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Target=System.out
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%-5p | %d{yyyy-MM-dd HH:mm:ss} | [%t] %C{2}:%L | %m%n

--- a/applet/build.gradle
+++ b/applet/build.gradle
@@ -126,7 +126,7 @@ javacard {
 
         //noinspection GroovyAssignabilityCheck
         cap {
-            packageName 'applet'
+            packageName 'applet.crypto'
             version '0.1'
             aid '01:ff:ff:04:05:06:07:08:09'
             output 'applet.cap'
@@ -142,7 +142,7 @@ javacard {
 
             //noinspection GroovyAssignabilityCheck
             applet {
-                className 'applet.HelloWorldApplet'
+                className 'CryptoApplet'
                 aid '01:ff:ff:04:05:06:07:08:09:01:02'
             }
 

--- a/applet/src/main/java/applet/crypto/AesCtr.java
+++ b/applet/src/main/java/applet/crypto/AesCtr.java
@@ -1,4 +1,4 @@
-package crypto;
+package applet.crypto;
 
 import javacard.framework.Util;
 import javacard.security.AESKey;

--- a/applet/src/main/java/applet/crypto/CryptoApplet.java
+++ b/applet/src/main/java/applet/crypto/CryptoApplet.java
@@ -1,4 +1,4 @@
-package crypto;
+package applet.crypto;
 
 import javacard.framework.*;
 

--- a/applet/src/main/java/applet/crypto/HmacSha256.java
+++ b/applet/src/main/java/applet/crypto/HmacSha256.java
@@ -1,4 +1,4 @@
-package crypto;
+package applet.crypto;
 
 import javacard.framework.ISOException;
 import javacard.framework.Util;

--- a/applet/src/main/java/applet/crypto/Utils.java
+++ b/applet/src/main/java/applet/crypto/Utils.java
@@ -1,0 +1,14 @@
+package applet.crypto;
+
+public class Utils {
+
+    public static void xor(
+            byte[] src, short srcOffset,
+            byte[] dst, short dstOffset,
+            short len
+    ) {
+        for (short i = 0; i < len; i++) {
+            dst[(short) (dstOffset + i)] ^= src[(short) (srcOffset + i)];
+        }
+    }
+}

--- a/applet/src/main/java/common/Utils.java
+++ b/applet/src/main/java/common/Utils.java
@@ -1,7 +1,6 @@
-package crypto;
+package common;
 
 public class Utils {
-
     public static byte[] parseHex(String s) {
         final int len = s.length();
 
@@ -42,15 +41,5 @@ public class Utils {
             r.append(hexCode[(b & 0xF)]);
         }
         return r.toString();
-    }
-
-    public static void xor(
-            byte[] src, short srcOffset,
-            byte[] dst, short dstOffset,
-            short len
-    ) {
-        for (short i = 0; i < len; i++) {
-            dst[(short) (dstOffset + i)] ^= src[(short) (srcOffset + i)];
-        }
     }
 }

--- a/applet/src/test/java/tests/AesCtrTest.java
+++ b/applet/src/test/java/tests/AesCtrTest.java
@@ -1,8 +1,7 @@
 package tests;
 
-import crypto.AesCtr;
-import crypto.CryptoApplet;
-import crypto.Utils;
+import applet.crypto.CryptoApplet;
+import common.Utils;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 

--- a/applet/src/test/java/tests/CryptoBase.java
+++ b/applet/src/test/java/tests/CryptoBase.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import com.licel.jcardsim.smartcardio.CardSimulator;
 import com.licel.jcardsim.utils.AIDUtil;
 
-import crypto.CryptoApplet;
+import applet.crypto.CryptoApplet;
 import javacard.framework.AID;
 
 public class CryptoBase {

--- a/applet/src/test/java/tests/HmacSha256Test.java
+++ b/applet/src/test/java/tests/HmacSha256Test.java
@@ -1,7 +1,7 @@
 package tests;
 
-import crypto.CryptoApplet;
-import crypto.Utils;
+import applet.crypto.CryptoApplet;
+import common.Utils;
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
 


### PR DESCRIPTION
Move applet-specific code into separate package, because compiling applet requires only that code.

Also, make crypto applet the default one, so it can be tested on the card.

And use the github actions for testing commits.