### PR TITLE
Use built-in hmac implementation

### DIFF
--- a/applet/src/main/java/applet/crypto/CryptoApplet.java
+++ b/applet/src/main/java/applet/crypto/CryptoApplet.java
@@ -10,7 +10,7 @@ public class CryptoApplet extends Applet {
 
     public static void install(byte[] bArray, short bOffset, byte bLength) {
         new CryptoApplet().register();
-        HmacSha256.init(JCSystem.makeTransientByteArray(HmacSha256.REQUIRED_BUFFER_LENGTH, JCSystem.CLEAR_ON_DESELECT));
+        HmacSha256.init();
         AesCtr.init(JCSystem.makeTransientByteArray(AesCtr.REQUIRED_BUFFER_LENGTH, JCSystem.CLEAR_ON_DESELECT));
         buffer = JCSystem.makeTransientByteArray((short) 1024, JCSystem.CLEAR_ON_DESELECT);
     }

--- a/applet/src/main/java/applet/crypto/HmacSha256.java
+++ b/applet/src/main/java/applet/crypto/HmacSha256.java
@@ -1,55 +1,29 @@
 package applet.crypto;
 
-import javacard.framework.ISOException;
-import javacard.framework.Util;
-import javacard.security.CryptoException;
-import javacard.security.MessageDigest;
+import javacard.security.*;
 
 public class HmacSha256 {
+    final public static short HMAC_SIZE = 32;
 
-    public static final short BLOCK_SIZE = 64;
-    public static final short HASH_SIZE = 32;
+    private static Signature hmac;
+    private static HMACKey hmacKey;
 
-    // When calling init, the buffer should be at least this length
-    public static final short REQUIRED_BUFFER_LENGTH = BLOCK_SIZE + HASH_SIZE;
-
-    // TODO: extract somewhere else
-    public static final short SW_HMAC_UNSUPPORTED_KEY_LENGTH = (short) 0x9c1E;
-
-    private static byte[] buffer;
-    private static MessageDigest sha256;
-
-    public static void init(byte[] tmp) {
-        sha256 = MessageDigest.getInstance(
-                MessageDigest.ALG_SHA_256,
-                false // externalAccess
+    public static void init() {
+        hmacKey = (HMACKey) KeyBuilder.buildKey(
+                KeyBuilder.TYPE_HMAC_TRANSIENT_DESELECT,
+                KeyBuilder.LENGTH_HMAC_SHA_256_BLOCK_64,
+                false // encrypt key
         );
-        buffer = tmp;
+        hmac = Signature.getInstance(
+                Signature.ALG_HMAC_SHA_256,
+                false // external access
+        );
     }
 
     public static void start(byte[] key, short keyOffset, short keyLength) {
         try {
-            // Sorry, we don't support big keys :c
-            if (keyLength > BLOCK_SIZE || keyLength < 0) {
-                ISOException.throwIt(SW_HMAC_UNSUPPORTED_KEY_LENGTH);
-            }
-
-            // Copy the key into the beginning of the buffer and xor producing the inner key
-            for (short i = 0; i < keyLength; i++) {
-                short k = (short) (keyOffset + i);
-                buffer[i] = (byte) (key[k] ^ 0x36);
-            }
-
-            // padd inner key to the block size
-            Util.arrayFillNonAtomic(
-                    buffer,
-                    keyLength, // offset, after the key
-                    (short) (BLOCK_SIZE - keyLength), // length, to the end of the BLOCK
-                    (byte) 0x36);
-
-            sha256.reset();
-            // write inner key
-            sha256.update(buffer, (short) 0, BLOCK_SIZE);
+            hmacKey.setKey(key, keyOffset, keyLength);
+            hmac.init(hmacKey, Signature.MODE_SIGN);
         } catch (CryptoException ex) {
             reset();
             throw ex;
@@ -58,7 +32,7 @@ public class HmacSha256 {
 
     public static void update(byte[] message, short messageOffset, short messageLength) {
         try {
-            sha256.update(message, messageOffset, messageLength);
+            hmac.update(message, messageOffset, messageLength);
         } catch (CryptoException ex) {
             reset();
             throw ex;
@@ -67,36 +41,17 @@ public class HmacSha256 {
 
     public static short finalize(byte[] mac, short macOffset) {
         try {
-            // write hash after the key in buffer
-            sha256.doFinal(
-                    // src
-                    buffer, (short)0, (short)0,
-                    buffer, // output
-                    BLOCK_SIZE // output offset; the hash will be after the inner key
-            );
+            hmac.sign(
+                    null, (short) 0, (short) 0,
+                    mac, macOffset);
 
-            // compute outer key
-            for (short i = 0; i < BLOCK_SIZE; i++) {
-                // (key xor 0x36) xor 0x36 xor 0x5c = key xor 0x5c
-                buffer[i] ^= 0x36 ^ 0x5c;
-            }
-
-            sha256.reset();
-            // compute hash from the `outer key || hash`
-            sha256.doFinal(buffer, (short) 0, (short) (BLOCK_SIZE + HASH_SIZE), mac, macOffset);
-
-            return HASH_SIZE;
+            return HMAC_SIZE;
         } finally {
             reset();
         }
     }
 
     public static void reset() {
-        sha256.reset();
-        // Zeroize the buffer
-        Util.arrayFillNonAtomic(
-                buffer, (short) 0, (short) buffer.length,
-                (byte) 0x00 // byte to fill with
-        );
+        hmacKey.clearKey();
     }
 }

--- a/applet/src/test/java/tests/HmacSha256Test.java
+++ b/applet/src/test/java/tests/HmacSha256Test.java
@@ -35,18 +35,8 @@ public class HmacSha256Test extends CryptoBase {
     }
 
     @Test
-    public void emptyKey() {
-        testWith("".getBytes(), "input".getBytes(), "d00c6678e09a0503bdbf68009b6af1c0593fe6a5318609540fef362e7c410219");
-    }
-
-    @Test
     public void emptyInput() {
         testWith("key".getBytes(), "".getBytes(), "5d5d139563c95b5967b9bd9a8c9b233a9dedb45072794cd232dc1b74832607d0");
-    }
-
-    @Test
-    public void emptyEverything() {
-        testWith("".getBytes(), "".getBytes(), "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad");
     }
 
     @Test


### PR DESCRIPTION
Should've read docs more carefully...

Also, the tests with empty keys were failling. They are removed, as it's probably for the better to forbid them.