### PR TITLE
Add AEAD

### DIFF
--- a/applet/src/main/java/applet/crypto/AEAD.java
+++ b/applet/src/main/java/applet/crypto/AEAD.java
@@ -1,0 +1,111 @@
+package applet.crypto;
+
+import javacard.framework.Util;
+import javacard.security.CryptoException;
+
+// Authenticated encryption with associated data;
+// The Underlying algorithm is aes-128-ctr-hmac-256-128
+// Which means that the cipher is aes-128-ctr
+// and the tag is computed as:
+// ```
+// digest = hmac-sha256(hmac_key, associated_data || encrypted_payload || nonce || length(associated_data).to_u64())
+// tag = truncate(digest, 16 bytes)
+// ```
+// The resulting ciphertext has the following format:
+// ```
+// [encrypted payload] [16-byte nonce] [16-byte tag]
+// ```
+//
+// The key is 48 bytes. First 16 bytes are used for AES, and the last
+// 32 are used for the tag.
+//
+public class AEAD {
+    public static final short NONCE_SIZE = AesCtr.NONCE_SIZE;
+    // We truncate output of the hmac
+    public static final short TAG_SIZE = 16;
+    public static final short ADDITIONAL_DATA_SIZE = NONCE_SIZE + TAG_SIZE;
+    public static final short KEY_SIZE = AesCtr.KEY_SIZE + HmacSha256.HMAC_SIZE;
+
+    public static final short AUTHENTICATION_ERROR = (short) 0x2d58;
+    public static final short CIPHERTEXT_TOO_SMALL = (short) 0xc849;
+
+    private static final short U64_SIZE = 8;
+    private static final short U64_OFFSET = 0;
+    private static final short HMAC_OUTPUT_OFFSET = U64_SIZE;
+
+    // [length of associated data in big endian format] + [hmac]
+    public static short REQUIRED_BUFFER_SIZE = U64_SIZE + HmacSha256.HMAC_SIZE;
+
+    private static byte[] buffer;
+
+    public static void init(byte[] buff) {
+        buffer = buff;
+    }
+
+    public static short geRequiredBufferLength(short plaintext) {
+        return (short) (plaintext + ADDITIONAL_DATA_SIZE);
+    }
+
+    public static short calculateTag(
+            byte[] key, short keyOffset, short keyLen,
+            byte[] ad, short adOffset, short adLen,
+            byte[] ciphertext, short ciphertextOffset, short ciphertextLen,
+            byte[] tag, short tagOffset) {
+        // Serialize associated data length as u64
+        Util.arrayFillNonAtomic(buffer, U64_OFFSET, U64_SIZE, (byte) 0x00);
+        Util.setShort(
+                buffer,
+                (short) (U64_OFFSET + 6), // length is 2 byte, so we set the last two bytes of the
+                                          // length buffer
+                adLen);
+
+        HmacSha256.start(key, keyOffset, keyLen);
+        HmacSha256.update(ad, adOffset, adLen);
+        HmacSha256.update(ciphertext, ciphertextOffset, ciphertextLen);
+        HmacSha256.update(buffer, (short) 0, U64_SIZE);
+        HmacSha256.finalize(buffer, HMAC_OUTPUT_OFFSET);
+
+        Util.arrayCopyNonAtomic(
+                buffer, HMAC_OUTPUT_OFFSET, // src
+                tag, tagOffset, // dest
+                TAG_SIZE);
+        return TAG_SIZE;
+    }
+
+    public static short open(
+            byte[] key, short keyOffset,
+            byte[] ciphertext, short cipherOffset, short cipherLen,
+            byte[] ad, short adOffset, short adLen) {
+        if (cipherLen < ADDITIONAL_DATA_SIZE) {
+            CryptoException.throwIt(CIPHERTEXT_TOO_SMALL);
+        }
+        // payloadLen is length of the actual data
+        short payloadLen = (short) (cipherLen - ADDITIONAL_DATA_SIZE);
+        short nonceOffset = (short) (cipherOffset + payloadLen);
+        short tagOffset = (short) (nonceOffset + TAG_SIZE);
+
+        // Split key
+        short encKeyOffset = keyOffset;
+        short tagKeyOffset = (short) (keyOffset + AesCtr.KEY_SIZE);
+
+        // Derive tag
+        calculateTag(
+                key, tagKeyOffset, HmacSha256.HMAC_SIZE, // tag key
+                ad, adOffset, adLen, // associated data
+                ciphertext, cipherOffset, (short) (payloadLen + NONCE_SIZE), // ciphertext
+                buffer, HMAC_OUTPUT_OFFSET // place tag in the buffer
+        );
+
+        boolean eq = Utils.const_eq(buffer, HMAC_OUTPUT_OFFSET, ciphertext, tagOffset, TAG_SIZE);
+        if (!eq) {
+            CryptoException.throwIt(AUTHENTICATION_ERROR);
+        }
+
+        AesCtr.decrypt(
+                key, encKeyOffset,
+                ciphertext, nonceOffset,
+                ciphertext, cipherOffset, payloadLen);
+
+        return payloadLen;
+    }
+}

--- a/applet/src/main/java/applet/crypto/CryptoApplet.java
+++ b/applet/src/main/java/applet/crypto/CryptoApplet.java
@@ -111,7 +111,11 @@ public class CryptoApplet extends Applet {
         short len = 0;
 
         if (seal) {
-            ISOException.throwIt(ISO7816.SW_INS_NOT_SUPPORTED);
+            len = AEAD.seal(
+                    buffer, keyOffset, // key
+                    buffer, dataOffset, dataLen, // plaintext
+                    buffer, adOffset, adLen // associated data
+            );
         } else {
             len = AEAD.open(
                     buffer, keyOffset, // key

--- a/applet/src/main/java/applet/crypto/Utils.java
+++ b/applet/src/main/java/applet/crypto/Utils.java
@@ -2,11 +2,18 @@ package applet.crypto;
 
 public class Utils {
 
+    public static boolean const_eq(byte[] a, short offsetA, byte[] b, short offsetB, short length) {
+        byte result = 0;
+        for (byte i = 0; i < length; i++) {
+            result |= (byte) (a[(short) (offsetA + i)] ^ b[(short) (offsetB + i)]);
+        }
+        return result == 0;
+    }
+
     public static void xor(
             byte[] src, short srcOffset,
             byte[] dst, short dstOffset,
-            short len
-    ) {
+            short len) {
         for (short i = 0; i < len; i++) {
             dst[(short) (dstOffset + i)] ^= src[(short) (srcOffset + i)];
         }

--- a/applet/src/test/java/tests/AEADTest.java
+++ b/applet/src/test/java/tests/AEADTest.java
@@ -1,0 +1,124 @@
+package tests;
+
+import applet.crypto.CryptoApplet;
+import common.Utils;
+import org.junit.Assert;
+import org.junit.jupiter.api.*;
+
+import javax.smartcardio.CommandAPDU;
+import javax.smartcardio.ResponseAPDU;
+
+public class AEADTest extends CryptoBase {
+    byte[] open(String keyHex, String hexCt, String ad) {
+        byte[] key = Utils.parseHex(keyHex);
+        byte[] data = Utils.parseHex(hexCt);
+
+        int keyOffset = 0;
+        int adLenOffset = key.length;
+        int adOffset = adLenOffset + 2;
+        int dataLenOffset = adOffset + ad.length();
+        int dataOffset = dataLenOffset + 2;
+
+        byte[] apduData = new byte[48 + 2 + ad.length() + 2 + data.length];
+        // resulting array is...
+        // 48 byte key
+        System.arraycopy(key, 0, apduData, keyOffset, key.length);
+        // then 2 byte length of associated data
+        putShort((short) ad.length(), apduData, adLenOffset);
+        // then associated data itself
+        System.arraycopy(ad.getBytes(), 0, apduData, adOffset, ad.length());
+        // then 2-byte data length
+        putShort((short) data.length, apduData, dataLenOffset);
+        // then data itself
+        System.arraycopy(data, 0, apduData, dataOffset, data.length);
+
+        CommandAPDU apdu = new CommandAPDU(0x00, CryptoApplet.INS_AEAD_OPEN, 0x00, 0x00, apduData);
+        ResponseAPDU response = card.transmitCommand(apdu);
+        Assert.assertEquals(SW_SUCCESS, response.getSW());
+        return response.getData();
+    }
+
+    @Test
+    void openEmptyDataEmptyAd() {
+        byte[] plaintext = open(
+                "882c64fb5a3be6ac2236f54e03efa3544770217b5da80dc42488da8e2a7c16bc5a76308ba25732369211845820520131",
+                "4fbbbd37b749d3ad0ef354f314afbb3b3eb172cf7f25f3b26ad37a2576df39ce",
+                "");
+        Assert.assertEquals("", new String(plaintext));
+    }
+
+    @Test
+    void openEmptyDataSmallAd() {
+        byte[] plaintext = open(
+                "4059868e7b7827fff97e792babc22fb80e42b599ab978112904cc8a151b599b230590c466e1ab7c7f383cffbaf253af3",
+                "a73fefc24bbbee7a67840bb61388e2b017a552a2386dfcb226f47563bc98421d",
+                "small");
+        Assert.assertEquals("", new String(plaintext));
+    }
+
+    @Test
+    void openEmptyDataBigAd() {
+        byte[] plaintext = open(
+                "2fed9cb3f35a9b107b09cd76828d808f521f3d988afc253eef8d02d98f65281e141830838095a0769113b8348746865a",
+                "5e33ecc0b4bf858739a318e0c2b1c77338bac07868af7bd60b93098e152ae727",
+                "biiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiig");
+        Assert.assertEquals("", new String(plaintext));
+    }
+
+    @Test
+    void openSmallDataEmptyAd() {
+        byte[] plaintext = open(
+                "b560391c8387172440cc334a42c22133d6f5befbaa8c2f6a5663a4f4575ca03f1e8592a329b9b4446a2e1c2c16fa4a5d",
+                "cc61434f55323120c5fab294535363d54a4a726150366a98fbc79243163d05c7734095744f",
+                "");
+        Assert.assertEquals("small", new String(plaintext));
+    }
+
+    @Test
+    void openSmallDataSmallAd() {
+        byte[] plaintext = open(
+                "f8339111823292b92ef4dfc900e6f0510ac2341f2b87ee2109f684d45826fb139fa157f29eb419a1873b445a70ce57df",
+                "9cd878e5826e22d26ff3d8a7fc68f088e3b64455d5fa0ae6eb8a76b03bd46f3ebd11ea895c",
+                "small");
+        Assert.assertEquals("small", new String(plaintext));
+    }
+
+    @Test
+    void openSmallDataBigAd() {
+        byte[] plaintext = open(
+                "ce5ae9de490a0a1b4feb23fb03240b07ef062a3751bf27dc5740aabf2ea31fd4d2a50d98223b07d44614bc95a4ab4b6c",
+                "2718055c6563c420cf582b64e6cd4ba7cb0e8f3097240428c86c70fb476809a5aa613ccd60",
+                "biiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiig");
+        Assert.assertEquals("small", new String(plaintext));
+    }
+
+    @Test
+    void openBigDataEmptyAd() {
+        byte[] plaintext = open(
+                "5ad4a62110f111e5f31596d7b2925c87dd22caa750aca37ba060f1b0bf53773be9dfa455e7e5ac4414c0ed4e4ebab8d3",
+                "eaf0a8be916d40af789a68b1dcb15c846ed7bc115ecf7fd5f51959c495ecf6b910237254cfbf7307f5addcbf9ec413c9fefd61f35e443a55917962798f8737f8f25654a1f11a366c021e572362778dda4bf95223a664899b875cdccbfaaf84316ee0db18636fc165",
+                "");
+        Assert.assertEquals("looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong",
+                new String(plaintext));
+    }
+
+    @Test
+    void openBigDataSmallAd() {
+        byte[] plaintext = open(
+                "6e6eb229600d02b60beb28cbf414afd6053348e7c8aa0f97e9c822901e411b387e5e66cb41d4eadfbef6997ee2b51538",
+                "bc4ba9a2a360ef139a96456731daf0d833c832a051a4f83d183d65192dc29fb21ae4fead274e1f222f0d555ab4937c12128b62d20ef95c5316dab9f57688bfd981fb6d91dc05121c6dcd7bdc618a66c9990ff2b49e0002edfe8651b33623b7c8780c69cae0bcdcb6",
+                "small");
+        Assert.assertEquals("looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong",
+                new String(plaintext));
+    }
+
+    @Test
+    void openBigDataBigAd() {
+        byte[] plaintext = open(
+                "a50db8256a7e8fb65952d96ceacbb62ed963f89fde79b4689ad2a7ac76638beeddcdcff99f2659d6d00504e896165302",
+                "5eb2df2480a52a41ce67b57d4fcf6f59999d1425d9dd7657670ecc0dfa664e97c15f754d47040082ac9f3cf34e369a682b54fce366be5868fbb45d5576a72ee589f7f9feed31538f52d5703b630d5d31eff02e923c1bac6b5cff5e3f897029d87199b9fdb2b490f3",
+                "biiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiig");
+        Assert.assertEquals("looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong",
+                new String(plaintext));
+    }
+}

--- a/applet/src/test/java/tests/CryptoBase.java
+++ b/applet/src/test/java/tests/CryptoBase.java
@@ -15,6 +15,8 @@ public class CryptoBase {
     protected CardSimulator card;
     protected final AID aid = AIDUtil.create("F000000001");
 
+    public static final int SW_SUCCESS = 0x9000;
+
     public CryptoBase() {
         card = new CardSimulator();
         card.installApplet(aid, CryptoApplet.class);


### PR DESCRIPTION
AEAD is authenticated encryption with associated data. This type of encryption guarantees not only secrecy, but also integrity of ciphertext.

Unfortunately, my card doesn't support standard modern AES-GCM or ChaCha-poly1305, so I had to create AEAD from the available primitives. The Underlying algorithm is aes-128-ctr-hmac-256-128. This monstrosity means that the cipher is aes-128-ctr
and the tag is computed with the HMAC-SHA256 truncated to 16 bytes.

The overall algorithm is as follows:
```
enc_key, hmac_key = key.split()
nonce = generate()

encrypted_payload = aes-ctr(enc_key, nonce, plaintext)

digest = hmac-sha256(hmac_key, associated_data || encrypted_payload || nonce || length(associated_data).to_u64())

tag = truncate(digest, 16 bytes)
return encrypted_payload + nonce + tag
```

The resulting ciphertext has the following format:

```
[encrypted payload] [16-byte nonce] [16-byte tag]
```

The key is 48 bytes. First 16 bytes are used for AES, and the last 32 are used for the tag, but I may change it in the future by deriving keys from one key material.
