### PR TITLE
Add P256

### DIFF
--- a/applet/build.gradle
+++ b/applet/build.gradle
@@ -53,11 +53,14 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.1.1'
+    testImplementation 'org.bouncycastle:bcprov-jdk15on:1.70'
+    testImplementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
+
 
     testImplementation(group: 'com.klinec', name: 'javacard-tools', version: '1.0.4') {
         exclude group: "com.klinec", module: "jcardsim"
     }
-    
+
     // Include plugin as it has bundled GP & other tools.
     // Alternative: include GP manually, but the included
     // version has to be compatible with the plugin.

--- a/applet/src/main/java/applet/crypto/P256.java
+++ b/applet/src/main/java/applet/crypto/P256.java
@@ -1,0 +1,94 @@
+package applet.crypto;
+
+import javacard.security.*;
+
+import static javacard.security.KeyAgreement.ALG_EC_SVDP_DH;
+
+public class P256 {
+
+    private static final byte SECP256R1_P[] = {
+            (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
+            (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
+            (byte) 0xff, (byte) 0xff
+    };
+    private static final byte SECP256R1_A[] = {
+            (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
+            (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
+            (byte) 0xff, (byte) 0xfc
+    };
+    private static final byte SECP256R1_B[] = {
+            (byte) 0x5a, (byte) 0xc6, (byte) 0x35, (byte) 0xd8, (byte) 0xaa, (byte) 0x3a,
+            (byte) 0x93, (byte) 0xe7, (byte) 0xb3, (byte) 0xeb, (byte) 0xbd, (byte) 0x55,
+            (byte) 0x76, (byte) 0x98, (byte) 0x86, (byte) 0xbc, (byte) 0x65, (byte) 0x1d,
+            (byte) 0x06, (byte) 0xb0, (byte) 0xcc, (byte) 0x53, (byte) 0xb0, (byte) 0xf6,
+            (byte) 0x3b, (byte) 0xce, (byte) 0x3c, (byte) 0x3e, (byte) 0x27, (byte) 0xd2,
+            (byte) 0x60, (byte) 0x4b
+    };
+    private static final byte SECP256R1_G[] = {
+            (byte) 0x04,
+            (byte) 0x6b, (byte) 0x17, (byte) 0xd1, (byte) 0xf2, (byte) 0xe1, (byte) 0x2c,
+            (byte) 0x42, (byte) 0x47, (byte) 0xf8, (byte) 0xbc, (byte) 0xe6, (byte) 0xe5,
+            (byte) 0x63, (byte) 0xa4, (byte) 0x40, (byte) 0xf2, (byte) 0x77, (byte) 0x03,
+            (byte) 0x7d, (byte) 0x81, (byte) 0x2d, (byte) 0xeb, (byte) 0x33, (byte) 0xa0,
+            (byte) 0xf4, (byte) 0xa1, (byte) 0x39, (byte) 0x45, (byte) 0xd8, (byte) 0x98,
+            (byte) 0xc2, (byte) 0x96,
+            (byte) 0x4f, (byte) 0xe3, (byte) 0x42, (byte) 0xe2, (byte) 0xfe, (byte) 0x1a,
+            (byte) 0x7f, (byte) 0x9b, (byte) 0x8e, (byte) 0xe7, (byte) 0xeb, (byte) 0x4a,
+            (byte) 0x7c, (byte) 0x0f, (byte) 0x9e, (byte) 0x16, (byte) 0x2b, (byte) 0xce,
+            (byte) 0x33, (byte) 0x57, (byte) 0x6b, (byte) 0x31, (byte) 0x5e, (byte) 0xce,
+            (byte) 0xcb, (byte) 0xb6, (byte) 0x40, (byte) 0x68, (byte) 0x37, (byte) 0xbf,
+            (byte) 0x51, (byte) 0xf5
+    };
+    private static final byte SECP256R1_R[] = {
+            (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
+            (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xbc, (byte) 0xe6,
+            (byte) 0xfa, (byte) 0xad, (byte) 0xa7, (byte) 0x17, (byte) 0x9e, (byte) 0x84,
+            (byte) 0xf3, (byte) 0xb9, (byte) 0xca, (byte) 0xc2, (byte) 0xfc, (byte) 0x63,
+            (byte) 0x25, (byte) 0x51
+    };
+
+    static final short KEY_SIZE_BITS = 256;
+
+    private static KeyAgreement keyAgreement;
+    private static KeyPair keyPair;
+
+    private static void setCurveParams(ECKey eckey) {
+        eckey.setFieldFP(SECP256R1_P, (short) 0, (short) (SECP256R1_P.length));
+        eckey.setA(SECP256R1_A, (short) 0, (short) (SECP256R1_A.length));
+        eckey.setB(SECP256R1_B, (short) 0, (short) (SECP256R1_B.length));
+        eckey.setG(SECP256R1_G, (short) 0, (short) (SECP256R1_G.length));
+        eckey.setR(SECP256R1_R, (short) 0, (short) (SECP256R1_R.length));
+    }
+
+    public static void init() {
+        keyAgreement = KeyAgreement.getInstance(ALG_EC_SVDP_DH, /* external access */ false);
+        keyPair = new KeyPair(KeyPair.ALG_EC_FP, KEY_SIZE_BITS);
+        setCurveParams((ECKey) keyPair.getPrivate());
+        setCurveParams((ECKey) keyPair.getPublic());
+    }
+
+    public static void generateNewKeypair() {
+        keyPair.genKeyPair();
+    }
+
+    public static short publicKey(byte[] dest, short destOffset) {
+        ECPublicKey pub = (ECPublicKey) keyPair.getPublic();
+        return pub.getW(dest, destOffset);
+    }
+
+    public static short ecdh(byte[] pub, short pubOffset, short pubLen, byte[] dest, short destOffset) {
+        keyAgreement.init(keyPair.getPrivate());
+        return keyAgreement.generateSecret(pub, pubOffset, pubLen, dest, destOffset);
+    }
+
+    public static void clean() {
+        keyPair.getPrivate().clearKey();
+    }
+}

--- a/applet/src/test/java/tests/CryptoBase.java
+++ b/applet/src/test/java/tests/CryptoBase.java
@@ -20,6 +20,8 @@ public class CryptoBase {
 
     public static final int SW_SUCCESS = 0x9000;
 
+    public static boolean isSimulator = true;
+
     public CryptoBase() {
         card = new CardSimulator();
         card.installApplet(aid, CryptoApplet.class);

--- a/applet/src/test/java/tests/CryptoBase.java
+++ b/applet/src/test/java/tests/CryptoBase.java
@@ -1,5 +1,6 @@
 package tests;
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -11,6 +12,8 @@ import com.licel.jcardsim.utils.AIDUtil;
 import applet.crypto.CryptoApplet;
 import javacard.framework.AID;
 
+import java.security.Security;
+
 public class CryptoBase {
     protected CardSimulator card;
     protected final AID aid = AIDUtil.create("F000000001");
@@ -21,6 +24,8 @@ public class CryptoBase {
         card = new CardSimulator();
         card.installApplet(aid, CryptoApplet.class);
         card.selectApplet(aid);
+
+        Security.addProvider(new BouncyCastleProvider());
     }
 
     void putShort(short a, byte[] arr, int offset) {

--- a/applet/src/test/java/tests/P256Test.java
+++ b/applet/src/test/java/tests/P256Test.java
@@ -1,0 +1,140 @@
+package tests;
+
+import applet.crypto.CryptoApplet;
+import common.Utils;
+import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.KeyAgreement;
+import javax.smartcardio.CommandAPDU;
+import javax.smartcardio.ResponseAPDU;
+
+
+import org.bouncycastle.asn1.x9.X9ECParameters;
+import org.bouncycastle.crypto.ec.CustomNamedCurves;
+import org.bouncycastle.jce.interfaces.ECPublicKey;
+import org.bouncycastle.jce.spec.ECParameterSpec;
+import org.bouncycastle.jce.spec.ECPublicKeySpec;
+
+import java.security.*;
+import java.security.spec.InvalidKeySpecException;
+
+public class P256Test extends CryptoBase {
+    public static final int SW_UNKNOWN = 0x6f00;
+
+
+    ResponseAPDU generateNewKeypair() {
+        CommandAPDU apdu = new CommandAPDU(0x00, CryptoApplet.INS_P256_GENERATE_NEW_KEYPAIR, 0x00, 0x00, new byte[] {});
+        return card.transmitCommand(apdu);
+    }
+
+    ResponseAPDU ecdh(byte[] pubkey) {
+        CommandAPDU apdu = new CommandAPDU(0x00, CryptoApplet.INS_P256_ECDH, 0x00, 0x00, pubkey);
+        return card.transmitCommand(apdu);
+    }
+
+    @Test
+    void generateKeyPairTest() throws InvalidKeySpecException, NoSuchAlgorithmException, NoSuchProviderException {
+        ResponseAPDU response = generateNewKeypair();
+        Assert.assertEquals(SW_SUCCESS, response.getSW());
+        byte[] encoded = response.getData();
+
+        // Will throws an error if the point is wrong
+        loadPublicKey(encoded);
+    }
+
+    @Test
+    void ecdhTest() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException, InvalidKeyException {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ECDH", "BC");
+        ECParameterSpec ecSpec = getParameterSpec();
+        keyGen.initialize(ecSpec, new SecureRandom());
+
+
+        ResponseAPDU response = generateNewKeypair();
+        Assert.assertEquals(SW_SUCCESS, response.getSW());
+        byte[] bobPublic = response.getData();
+
+        System.out.println("Bob public: " + Utils.toHex(bobPublic));
+
+        ECPublicKey bob = loadPublicKey(bobPublic);
+
+        KeyPair alice = keyGen.generateKeyPair();
+        KeyAgreement aliceAgree = KeyAgreement.getInstance("ECDH", "BC");
+        aliceAgree.init(alice.getPrivate());
+
+        aliceAgree.doPhase(bob, true);
+
+        MessageDigest hash = MessageDigest.getInstance("SHA1", "BC");
+        byte[] aliceShared = hash.digest(aliceAgree.generateSecret());
+
+        byte[] alicePub = ((BCECPublicKey) alice.getPublic()).getQ().getEncoded(false);
+
+        System.out.println("Alice public: " + Utils.toHex(alicePub));
+
+        response = ecdh(alicePub);
+        Assertions.assertEquals(SW_SUCCESS, response.getSW());
+        byte[] bobShared = response.getData();
+
+        Assert.assertEquals(Utils.toHex(aliceShared), Utils.toHex(bobShared));
+    }
+
+    void testWith(String maliciousPublicKey) {
+        ResponseAPDU response = generateNewKeypair();
+        Assert.assertEquals(SW_SUCCESS, response.getSW());
+
+        byte[] alicePub = Utils.parseHex(maliciousPublicKey);
+        response = ecdh(alicePub);
+
+        Assertions.assertEquals(SW_UNKNOWN, response.getSW());
+    }
+
+    @Test
+    void XEqualPCompressed() {
+        testWith("03ffffffff00000001000000000000000000000000ffffffffffffffffffffffff");
+    }
+
+    @Test
+    void XYEqualP() {
+        testWith("04ffffffff00000001000000000000000000000000ffffffffffffffffffffffffffffffff00000001000000000000000000000000ffffffffffffffffffffffff");
+    }
+
+
+    @Test
+    void XGreaterThanPCompressed() {
+        testWith("02ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    }
+
+    @Test
+    void XYGreaterThanP() {
+        testWith("04ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    }
+
+    @Test
+    void XNotOnCurveCompressed() {
+        testWith("02ae2336ae573e1418b544cf930b37c0c57bf047096aa7218b5786ec8ef53a228e");
+    }
+
+    @Test
+    void XYNotOnCurve() {
+        testWith("04a1a0f443179fbc06ee046af7e8a9f27f50f129d9df32a77f4ed7a641ffb86367f610e2449c9c07af47a1f425d3ac513fbeee634066d456dea315c256544a7b48");
+    }
+
+    public static ECPublicKey loadPublicKey(byte[] data)
+            throws InvalidKeySpecException, NoSuchAlgorithmException, NoSuchProviderException {
+        ECParameterSpec ecParameterSpec = getParameterSpec();
+        ECPublicKeySpec publicKey = new ECPublicKeySpec(ecParameterSpec.getCurve().decodePoint(data), ecParameterSpec);
+        KeyFactory kf = KeyFactory.getInstance("ECDH", "BC");
+        return (ECPublicKey) kf.generatePublic(publicKey);
+    }
+
+    @NotNull
+    public static ECParameterSpec getParameterSpec() {
+        X9ECParameters params = CustomNamedCurves.getByName("secp256r1");
+        ECParameterSpec ecParameterSpec = new ECParameterSpec(params.getCurve(), params.getG(), params.getN(),
+                params.getH(), params.getSeed());
+        return ecParameterSpec;
+    }
+}

--- a/applet/src/test/java/tests/P256Test.java
+++ b/applet/src/test/java/tests/P256Test.java
@@ -6,6 +6,7 @@ import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import javax.crypto.KeyAgreement;
@@ -119,6 +120,7 @@ public class P256Test extends CryptoBase {
 
     @Test
     void XYNotOnCurve() {
+        Assumptions.assumeFalse(isSimulator);
         testWith("04a1a0f443179fbc06ee046af7e8a9f27f50f129d9df32a77f4ed7a641ffb86367f610e2449c9c07af47a1f425d3ac513fbeee634066d456dea315c256544a7b48");
     }
 


### PR DESCRIPTION
Add a simple wrapper of core javacard ECDH utilities with p256 parameters. I would like to use something like ed25119 or more safe curve, but P256 is standardized so it would be easier to integrate it with clients.

There are also a bunch of tests for ECDH points validation. Some of them are failing on JSim, so they are disabled by now.