### PR TITLE
Allow running tests physically

### DIFF
--- a/applet/src/main/java/applet/crypto/AEAD.java
+++ b/applet/src/main/java/applet/crypto/AEAD.java
@@ -1,7 +1,8 @@
 package applet.crypto;
 
+import javacard.framework.CardRuntimeException;
+import javacard.framework.ISOException;
 import javacard.framework.Util;
-import javacard.security.CryptoException;
 
 // Authenticated encryption with associated data;
 // The Underlying algorithm is aes-128-ctr-hmac-256-128
@@ -110,7 +111,7 @@ public class AEAD {
             byte[] ciphertext, short cipherOffset, short cipherLen,
             byte[] ad, short adOffset, short adLen) {
         if (cipherLen < ADDITIONAL_DATA_SIZE) {
-            CryptoException.throwIt(CIPHERTEXT_TOO_SMALL);
+            ISOException.throwIt(CIPHERTEXT_TOO_SMALL);
         }
         // payloadLen is length of the actual data
         short payloadLen = (short) (cipherLen - ADDITIONAL_DATA_SIZE);
@@ -131,7 +132,7 @@ public class AEAD {
 
         boolean eq = Utils.const_eq(buffer, HMAC_OUTPUT_OFFSET, ciphertext, tagOffset, TAG_SIZE);
         if (!eq) {
-            CryptoException.throwIt(AUTHENTICATION_ERROR);
+            ISOException.throwIt(AUTHENTICATION_ERROR);
         }
 
         AesCtr.decrypt(

--- a/applet/src/test/java/tests/AEADTest.java
+++ b/applet/src/test/java/tests/AEADTest.java
@@ -11,7 +11,7 @@ import javax.smartcardio.ResponseAPDU;
 import java.security.SecureRandom;
 
 public class AEADTest extends CryptoBase {
-    ResponseAPDU aeadRaw(short ins, byte[] key, byte[] ad, byte[] data) {
+    ResponseAPDU aeadRaw(short ins, byte[] key, byte[] ad, byte[] data) throws Exception {
         int keyOffset = 0;
         int adLenOffset = key.length;
         int adOffset = adLenOffset + 2;
@@ -32,30 +32,30 @@ public class AEADTest extends CryptoBase {
         System.arraycopy(data, 0, apduData, dataOffset, data.length);
 
         CommandAPDU apdu = new CommandAPDU(0x00, ins, 0x00, 0x00, apduData);
-        ResponseAPDU response = card.transmitCommand(apdu);
+        ResponseAPDU response = card.transmit(apdu);
         return response;
     }
 
-    byte[] aead(short ins, byte[] key, byte[] ad, byte[] data) {
+    byte[] aead(short ins, byte[] key, byte[] ad, byte[] data) throws Exception {
         ResponseAPDU res = aeadRaw(ins, key, ad, data);
         Assert.assertEquals(SW_SUCCESS, res.getSW());
         return res.getData();
     }
 
-    byte[] open(String keyHex, String hexCt, String ad) {
+    byte[] open(String keyHex, String hexCt, String ad) throws Exception {
         byte[] key = Utils.parseHex(keyHex);
         byte[] data = Utils.parseHex(hexCt);
 
         return aead(CryptoApplet.INS_AEAD_OPEN, key, ad.getBytes(), data);
     }
 
-    byte[] seal(String keyHex, String plaintext, String ad) {
+    byte[] seal(String keyHex, String plaintext, String ad) throws Exception {
         byte[] key = Utils.parseHex(keyHex);
         return aead(CryptoApplet.INS_AEAD_SEAL, key, ad.getBytes(), plaintext.getBytes());
     }
 
     @Test
-    void openEmptyDataEmptyAd() {
+    void openEmptyDataEmptyAd() throws Exception {
         byte[] plaintext = open(
                 "882c64fb5a3be6ac2236f54e03efa3544770217b5da80dc42488da8e2a7c16bc5a76308ba25732369211845820520131",
                 "4fbbbd37b749d3ad0ef354f314afbb3b3eb172cf7f25f3b26ad37a2576df39ce",
@@ -64,7 +64,7 @@ public class AEADTest extends CryptoBase {
     }
 
     @Test
-    void openEmptyDataSmallAd() {
+    void openEmptyDataSmallAd() throws Exception {
         byte[] plaintext = open(
                 "4059868e7b7827fff97e792babc22fb80e42b599ab978112904cc8a151b599b230590c466e1ab7c7f383cffbaf253af3",
                 "a73fefc24bbbee7a67840bb61388e2b017a552a2386dfcb226f47563bc98421d",
@@ -73,7 +73,7 @@ public class AEADTest extends CryptoBase {
     }
 
     @Test
-    void openEmptyDataBigAd() {
+    void openEmptyDataBigAd() throws Exception {
         byte[] plaintext = open(
                 "2fed9cb3f35a9b107b09cd76828d808f521f3d988afc253eef8d02d98f65281e141830838095a0769113b8348746865a",
                 "5e33ecc0b4bf858739a318e0c2b1c77338bac07868af7bd60b93098e152ae727",
@@ -82,7 +82,7 @@ public class AEADTest extends CryptoBase {
     }
 
     @Test
-    void openSmallDataEmptyAd() {
+    void openSmallDataEmptyAd() throws Exception {
         byte[] plaintext = open(
                 "b560391c8387172440cc334a42c22133d6f5befbaa8c2f6a5663a4f4575ca03f1e8592a329b9b4446a2e1c2c16fa4a5d",
                 "cc61434f55323120c5fab294535363d54a4a726150366a98fbc79243163d05c7734095744f",
@@ -91,7 +91,7 @@ public class AEADTest extends CryptoBase {
     }
 
     @Test
-    void openSmallDataSmallAd() {
+    void openSmallDataSmallAd() throws Exception {
         byte[] plaintext = open(
                 "f8339111823292b92ef4dfc900e6f0510ac2341f2b87ee2109f684d45826fb139fa157f29eb419a1873b445a70ce57df",
                 "9cd878e5826e22d26ff3d8a7fc68f088e3b64455d5fa0ae6eb8a76b03bd46f3ebd11ea895c",
@@ -100,7 +100,7 @@ public class AEADTest extends CryptoBase {
     }
 
     @Test
-    void openSmallDataBigAd() {
+    void openSmallDataBigAd() throws Exception {
         byte[] plaintext = open(
                 "ce5ae9de490a0a1b4feb23fb03240b07ef062a3751bf27dc5740aabf2ea31fd4d2a50d98223b07d44614bc95a4ab4b6c",
                 "2718055c6563c420cf582b64e6cd4ba7cb0e8f3097240428c86c70fb476809a5aa613ccd60",
@@ -109,7 +109,7 @@ public class AEADTest extends CryptoBase {
     }
 
     @Test
-    void openBigDataEmptyAd() {
+    void openBigDataEmptyAd() throws Exception {
         byte[] plaintext = open(
                 "5ad4a62110f111e5f31596d7b2925c87dd22caa750aca37ba060f1b0bf53773be9dfa455e7e5ac4414c0ed4e4ebab8d3",
                 "eaf0a8be916d40af789a68b1dcb15c846ed7bc115ecf7fd5f51959c495ecf6b910237254cfbf7307f5addcbf9ec413c9fefd61f35e443a55917962798f8737f8f25654a1f11a366c021e572362778dda4bf95223a664899b875cdccbfaaf84316ee0db18636fc165",
@@ -119,7 +119,7 @@ public class AEADTest extends CryptoBase {
     }
 
     @Test
-    void openBigDataSmallAd() {
+    void openBigDataSmallAd() throws Exception {
         byte[] plaintext = open(
                 "6e6eb229600d02b60beb28cbf414afd6053348e7c8aa0f97e9c822901e411b387e5e66cb41d4eadfbef6997ee2b51538",
                 "bc4ba9a2a360ef139a96456731daf0d833c832a051a4f83d183d65192dc29fb21ae4fead274e1f222f0d555ab4937c12128b62d20ef95c5316dab9f57688bfd981fb6d91dc05121c6dcd7bdc618a66c9990ff2b49e0002edfe8651b33623b7c8780c69cae0bcdcb6",
@@ -129,7 +129,7 @@ public class AEADTest extends CryptoBase {
     }
 
     @Test
-    void openBigDataBigAd() {
+    void openBigDataBigAd() throws Exception {
         byte[] plaintext = open(
                 "a50db8256a7e8fb65952d96ceacbb62ed963f89fde79b4689ad2a7ac76638beeddcdcff99f2659d6d00504e896165302",
                 "5eb2df2480a52a41ce67b57d4fcf6f59999d1425d9dd7657670ecc0dfa664e97c15f754d47040082ac9f3cf34e369a682b54fce366be5868fbb45d5576a72ee589f7f9feed31538f52d5703b630d5d31eff02e923c1bac6b5cff5e3f897029d87199b9fdb2b490f3",
@@ -138,7 +138,7 @@ public class AEADTest extends CryptoBase {
                 new String(plaintext));
     }
 
-    void encryptDecrypt(String text, String ad) {
+    void encryptDecrypt(String text, String ad) throws Exception {
         SecureRandom random = new SecureRandom();
         byte[] key = random.generateSeed(48);
         String keyHex = Utils.toHex(key);
@@ -150,52 +150,52 @@ public class AEADTest extends CryptoBase {
     }
 
     @Test
-    void encryptDecryptEmptyPlaintextEmptyAD() {
+    void encryptDecryptEmptyPlaintextEmptyAD() throws Exception {
         encryptDecrypt("", "");
     }
 
     @Test
-    void encryptDecryptEmptyPlaintextSmallAD() {
+    void encryptDecryptEmptyPlaintextSmallAD() throws Exception {
         encryptDecrypt("", "small");
     }
 
     @Test
-    void encryptDecryptEmptyPlaintextBigAD() {
+    void encryptDecryptEmptyPlaintextBigAD() throws Exception {
         encryptDecrypt("", "biiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiig");
     }
 
     @Test
-    void encryptDecryptSmallPlaintextEmptyAD() {
+    void encryptDecryptSmallPlaintextEmptyAD() throws Exception {
         encryptDecrypt("small", "");
     }
 
     @Test
-    void encryptDecryptSmallPlaintextSmallAD() {
+    void encryptDecryptSmallPlaintextSmallAD() throws Exception {
         encryptDecrypt("small", "smallish");
     }
 
     @Test
-    void encryptDecryptSmallPlaintextBigAD() {
+    void encryptDecryptSmallPlaintextBigAD() throws Exception {
         encryptDecrypt("small", "biiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiig");
     }
 
     @Test
-    void encryptDecryptBigPlaintextEmptyAD() {
+    void encryptDecryptBigPlaintextEmptyAD() throws Exception {
         encryptDecrypt("BIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIG", "");
     }
 
     @Test
-    void encryptDecryptBigPlaintextSmallAD() {
+    void encryptDecryptBigPlaintextSmallAD() throws Exception {
         encryptDecrypt("BIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIG", "small");
     }
 
     @Test
-    void encryptDecryptBigPlaintextBigAD() {
+    void encryptDecryptBigPlaintextBigAD() throws Exception {
         encryptDecrypt("BIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIG", "huuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuge");
     }
 
     @Test
-    void encryptFlipByteDecrypt() {
+    void encryptFlipByteDecrypt() throws Exception {
         SecureRandom random = new SecureRandom();
         byte[] key = random.generateSeed(48);
         String keyHex = Utils.toHex(key);
@@ -211,7 +211,7 @@ public class AEADTest extends CryptoBase {
     }
 
     @Test
-    void encryptFlipTagDecrypt() {
+    void encryptFlipTagDecrypt() throws Exception {
         SecureRandom random = new SecureRandom();
         byte[] key = random.generateSeed(48);
         String keyHex = Utils.toHex(key);
@@ -227,7 +227,7 @@ public class AEADTest extends CryptoBase {
     }
 
     @Test
-    void encryptFlipNonceDecrypt() {
+    void encryptFlipNonceDecrypt() throws Exception {
         SecureRandom random = new SecureRandom();
         byte[] key = random.generateSeed(48);
         String keyHex = Utils.toHex(key);

--- a/applet/src/test/java/tests/AesCtrTest.java
+++ b/applet/src/test/java/tests/AesCtrTest.java
@@ -9,15 +9,15 @@ import javax.smartcardio.CommandAPDU;
 import javax.smartcardio.ResponseAPDU;
 
 public class AesCtrTest extends CryptoBase {
-    void testEncrypt(String keyHex, String nonceHex, String dataHex, String expectedHex) {
+    void testEncrypt(String keyHex, String nonceHex, String dataHex, String expectedHex) throws Exception {
         testIns(CryptoApplet.INS_AES_CTR_ENC, keyHex, nonceHex, dataHex, expectedHex);
     }
 
-    void testDecrypt(String keyHex, String nonceHex, String dataHex, String expectedHex) {
+    void testDecrypt(String keyHex, String nonceHex, String dataHex, String expectedHex) throws Exception {
         testIns(CryptoApplet.INS_AES_CTR_DEC, keyHex, nonceHex, dataHex, expectedHex);
     }
 
-    void testIns(byte ins, String keyHex, String nonceHex, String dataHex, String expectedHex) {
+    void testIns(byte ins, String keyHex, String nonceHex, String dataHex, String expectedHex) throws Exception {
         byte[] key = Utils.parseHex(keyHex);
         byte[] nonce = Utils.parseHex(nonceHex);
         byte[] data = Utils.parseHex(dataHex);
@@ -34,14 +34,14 @@ public class AesCtrTest extends CryptoBase {
         System.arraycopy(data, 0, apduData, 34, data.length);
 
         CommandAPDU apdu = new CommandAPDU(0x00, ins, 0x00, 0x00, apduData);
-        ResponseAPDU response = card.transmitCommand(apdu);
+        ResponseAPDU response = card.transmit(apdu);
         byte[] raw = response.getData();
 
         Assert.assertEquals(expectedHex, Utils.toHex(raw));
     }
 
     @Test
-    public void simple() {
+    public void simple() throws Exception {
         testEncrypt(
                 "00112233445566778899aabbccddeeff",
                 "ffeeddccbbaa99887766554433221100",
@@ -56,7 +56,7 @@ public class AesCtrTest extends CryptoBase {
     }
 
     @Test
-    public void empty() {
+    public void empty() throws Exception {
         testEncrypt(
                 "00112233445566778899aabbccddeeff",
                 "ffeeddccbbaa99887766554433221100",
@@ -71,7 +71,7 @@ public class AesCtrTest extends CryptoBase {
     }
 
     @Test
-    public void oneByte() {
+    public void oneByte() throws Exception {
         testEncrypt(
                 "00112233445566778899aabbccddeeff",
                 "ffeeddccbbaa99887766554433221100",
@@ -86,7 +86,7 @@ public class AesCtrTest extends CryptoBase {
     }
 
     @Test
-    public void oneLessThanBlockSize() {
+    public void oneLessThanBlockSize() throws Exception {
         testEncrypt(
                 "00112233445566778899aabbccddeeff",
                 "ffeeddccbbaa99887766554433221100",
@@ -101,7 +101,7 @@ public class AesCtrTest extends CryptoBase {
     }
 
     @Test
-    public void overflowCounter() {
+    public void overflowCounter() throws Exception {
         testEncrypt(
                 "00112233445566778899aabbccddeeff",
                 "fffffffffffffffffffffffffffffffa",

--- a/applet/src/test/java/tests/CryptoBase.java
+++ b/applet/src/test/java/tests/CryptoBase.java
@@ -6,27 +6,30 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
-import com.licel.jcardsim.smartcardio.CardSimulator;
 import com.licel.jcardsim.utils.AIDUtil;
 
 import applet.crypto.CryptoApplet;
 import javacard.framework.AID;
+import tests.jcard.Card;
+import tests.jcard.PhysicalCard;
+import tests.jcard.SimulatorCard;
 
 import java.security.Security;
 
 public class CryptoBase {
-    protected CardSimulator card;
+    protected Card card;
     protected final AID aid = AIDUtil.create("F000000001");
 
     public static final int SW_SUCCESS = 0x9000;
 
-    public static boolean isSimulator = true;
+    public static boolean simulated = true;
 
     public CryptoBase() {
-        card = new CardSimulator();
-        card.installApplet(aid, CryptoApplet.class);
-        card.selectApplet(aid);
-
+        if (simulated) {
+            card = new SimulatorCard(aid, CryptoApplet.class);
+        } else {
+            card = new PhysicalCard();
+        }
         Security.addProvider(new BouncyCastleProvider());
     }
 
@@ -45,10 +48,11 @@ public class CryptoBase {
 
     @BeforeEach
     public void setUpMethod() throws Exception {
-
+        card.connect();
     }
 
     @AfterEach
     public void tearDownMethod() throws Exception {
+        card.disconnect();
     }
 }

--- a/applet/src/test/java/tests/HmacSha256Test.java
+++ b/applet/src/test/java/tests/HmacSha256Test.java
@@ -9,7 +9,7 @@ import javax.smartcardio.CommandAPDU;
 import javax.smartcardio.ResponseAPDU;
 
 public class HmacSha256Test extends CryptoBase {
-    void testWith(byte[] key, byte[] data, String expected) {
+    void testWith(byte[] key, byte[] data, String expected) throws Exception {
         byte[] apduData = new byte[2 + key.length + 2 + data.length];
         // resulting array is...
         // 2 byte key length
@@ -22,42 +22,42 @@ public class HmacSha256Test extends CryptoBase {
         System.arraycopy(data, 0, apduData, 2 + key.length + 2, data.length);
 
         CommandAPDU apdu = new CommandAPDU(0x00, CryptoApplet.INS_HMAC_SHA256, 0x00, 0x00, apduData);
-        ResponseAPDU response = card.transmitCommand(apdu);
+        ResponseAPDU response = card.transmit(apdu);
         byte[] raw = response.getData();
 
         Assert.assertEquals(expected, Utils.toHex(raw));
     }
 
     @Test
-    public void simple() {
+    public void simple() throws Exception {
         testWith("key".getBytes(), "input".getBytes(),
                 "9e089ec13af881a8ac227a736c3e7c490ea3b4afca0c5f83dff6393b683a72e3");
     }
 
     @Test
-    public void emptyKey() {
+    public void emptyKey() throws Exception {
         testWith("".getBytes(), "input".getBytes(), "d00c6678e09a0503bdbf68009b6af1c0593fe6a5318609540fef362e7c410219");
     }
 
     @Test
-    public void emptyInput() {
+    public void emptyInput() throws Exception {
         testWith("key".getBytes(), "".getBytes(), "5d5d139563c95b5967b9bd9a8c9b233a9dedb45072794cd232dc1b74832607d0");
     }
 
     @Test
-    public void emptyEverything() {
+    public void emptyEverything() throws Exception {
         testWith("".getBytes(), "".getBytes(), "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad");
     }
 
     @Test
-    public void bigInput() {
+    public void bigInput() throws Exception {
         String input = "glory to Ukraine!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!";
         testWith("key".getBytes(), input.getBytes(),
                 "97e1db8880a996504eaf58f7fc6c097b26341ce8b1397b3d8b2fe1e48b64be58");
     }
 
     @Test
-    public void bigKey() {
+    public void bigKey() throws Exception {
         String key = "fuck russians|fuck russians|fuck russians|fuck russians|fuck ru."; // 64 bytes, block size
         testWith(key.getBytes(), "input".getBytes(),
                 "485ea83cf99992e5655e1860d2115c347d131dcc8c897b519aabf419f7fdf2c5");

--- a/applet/src/test/java/tests/P256Test.java
+++ b/applet/src/test/java/tests/P256Test.java
@@ -27,18 +27,18 @@ public class P256Test extends CryptoBase {
     public static final int SW_UNKNOWN = 0x6f00;
 
 
-    ResponseAPDU generateNewKeypair() {
+    ResponseAPDU generateNewKeypair() throws Exception {
         CommandAPDU apdu = new CommandAPDU(0x00, CryptoApplet.INS_P256_GENERATE_NEW_KEYPAIR, 0x00, 0x00, new byte[] {});
-        return card.transmitCommand(apdu);
+        return card.transmit(apdu);
     }
 
-    ResponseAPDU ecdh(byte[] pubkey) {
+    ResponseAPDU ecdh(byte[] pubkey) throws Exception {
         CommandAPDU apdu = new CommandAPDU(0x00, CryptoApplet.INS_P256_ECDH, 0x00, 0x00, pubkey);
-        return card.transmitCommand(apdu);
+        return card.transmit(apdu);
     }
 
     @Test
-    void generateKeyPairTest() throws InvalidKeySpecException, NoSuchAlgorithmException, NoSuchProviderException {
+    void generateKeyPairTest() throws Exception {
         ResponseAPDU response = generateNewKeypair();
         Assert.assertEquals(SW_SUCCESS, response.getSW());
         byte[] encoded = response.getData();
@@ -48,7 +48,7 @@ public class P256Test extends CryptoBase {
     }
 
     @Test
-    void ecdhTest() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException, InvalidKeyException {
+    void ecdhTest() throws Exception {
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ECDH", "BC");
         ECParameterSpec ecSpec = getParameterSpec();
         keyGen.initialize(ecSpec, new SecureRandom());
@@ -82,7 +82,7 @@ public class P256Test extends CryptoBase {
         Assert.assertEquals(Utils.toHex(aliceShared), Utils.toHex(bobShared));
     }
 
-    void testWith(String maliciousPublicKey) {
+    void testWith(String maliciousPublicKey) throws Exception {
         ResponseAPDU response = generateNewKeypair();
         Assert.assertEquals(SW_SUCCESS, response.getSW());
 
@@ -93,34 +93,34 @@ public class P256Test extends CryptoBase {
     }
 
     @Test
-    void XEqualPCompressed() {
+    void XEqualPCompressed() throws Exception {
         testWith("03ffffffff00000001000000000000000000000000ffffffffffffffffffffffff");
     }
 
     @Test
-    void XYEqualP() {
+    void XYEqualP() throws Exception {
         testWith("04ffffffff00000001000000000000000000000000ffffffffffffffffffffffffffffffff00000001000000000000000000000000ffffffffffffffffffffffff");
     }
 
 
     @Test
-    void XGreaterThanPCompressed() {
+    void XGreaterThanPCompressed() throws Exception {
         testWith("02ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     }
 
     @Test
-    void XYGreaterThanP() {
+    void XYGreaterThanP() throws Exception {
         testWith("04ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     }
 
     @Test
-    void XNotOnCurveCompressed() {
+    void XNotOnCurveCompressed() throws Exception {
         testWith("02ae2336ae573e1418b544cf930b37c0c57bf047096aa7218b5786ec8ef53a228e");
     }
 
     @Test
-    void XYNotOnCurve() {
-        Assumptions.assumeFalse(isSimulator);
+    void XYNotOnCurve() throws Exception {
+        Assumptions.assumeFalse(simulated);
         testWith("04a1a0f443179fbc06ee046af7e8a9f27f50f129d9df32a77f4ed7a641ffb86367f610e2449c9c07af47a1f425d3ac513fbeee634066d456dea315c256544a7b48");
     }
 

--- a/applet/src/test/java/tests/RngTest.java
+++ b/applet/src/test/java/tests/RngTest.java
@@ -11,16 +11,16 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class RngTest extends CryptoBase {
-    byte[] rand(short len) {
+    byte[] rand(short len) throws Exception {
         byte[] apduData = new byte[2];
         putShort((short) len, apduData, 0);
         CommandAPDU apdu = new CommandAPDU(0x00, CryptoApplet.INS_RAND, 0x00, 0x00, apduData);
-        ResponseAPDU response = card.transmitCommand(apdu);
+        ResponseAPDU response = card.transmit(apdu);
         return response.getData();
     }
 
     @Test
-    public void checkLength() {
+    public void checkLength() throws Exception {
         for (short i = 0; i < 128; i++) {
             byte[] random = rand(i);
             Assert.assertEquals(i, random.length);
@@ -28,16 +28,21 @@ public class RngTest extends CryptoBase {
     }
 
     @Test
-    public void dontRepeatAfterDeselect() {
+    public void dontRepeatAfterDeselect() throws Exception {
         Set<byte[]> set = new HashSet<>();
 
         int numberOfRequests = 128;
 
-        card.selectApplet(aid);
+        card.disconnect();
+        card.connect();
+
         for (int i = 0; i < numberOfRequests; i++) {
             set.add(rand((short) 32));
         }
-        card.selectApplet(aid);
+
+        card.disconnect();
+        card.connect();
+
         for (int i = 0; i < numberOfRequests; i++) {
             set.add(rand((short) 32));
         }
@@ -45,12 +50,13 @@ public class RngTest extends CryptoBase {
     }
 
     @Test
-    public void dontRepeatAfterReseed() {
+    public void dontRepeatAfterReseed() throws Exception {
         Set<byte[]> set = new HashSet<>();
 
         int numberOfRequests = 1024;
 
-        card.selectApplet(aid);
+        card.disconnect();
+        card.connect();
         for (int i = 0; i < numberOfRequests; i++) {
             set.add(rand((short) 32));
         }

--- a/applet/src/test/java/tests/jcard/Card.java
+++ b/applet/src/test/java/tests/jcard/Card.java
@@ -1,0 +1,12 @@
+package tests.jcard;
+
+import javax.smartcardio.CardException;
+import javax.smartcardio.CommandAPDU;
+import javax.smartcardio.ResponseAPDU;
+
+public abstract class Card {
+    abstract public void connect() throws Exception;
+    abstract public void disconnect() throws Exception;
+
+    abstract public ResponseAPDU transmit(CommandAPDU apdu) throws Exception;
+}

--- a/applet/src/test/java/tests/jcard/PhysicalCard.java
+++ b/applet/src/test/java/tests/jcard/PhysicalCard.java
@@ -1,0 +1,35 @@
+package tests.jcard;
+
+import javax.smartcardio.CardChannel;
+import javax.smartcardio.TerminalFactory;
+import javax.smartcardio.ResponseAPDU;
+import javax.smartcardio.CardTerminal;
+import javax.smartcardio.CommandAPDU;
+
+import java.util.List;
+
+public class PhysicalCard extends Card {
+
+    javax.smartcardio.Card card;
+
+    @Override
+    public void connect() throws Exception {
+        TerminalFactory factory = TerminalFactory.getDefault();
+        List<CardTerminal> terminals = factory.terminals().list();
+        System.out.println("Terminals: " + terminals);
+        CardTerminal terminal = terminals.get(0);
+        card = terminal.connect("T=0");
+    }
+
+    @Override
+    public void disconnect() throws Exception {
+        card.disconnect(false);
+        card = null;
+    }
+
+    @Override
+    public ResponseAPDU transmit(CommandAPDU apdu) throws Exception {
+        CardChannel channel = card.getBasicChannel();
+        return channel.transmit(apdu);
+    }
+}

--- a/applet/src/test/java/tests/jcard/SimulatorCard.java
+++ b/applet/src/test/java/tests/jcard/SimulatorCard.java
@@ -1,0 +1,35 @@
+package tests.jcard;
+
+import com.licel.jcardsim.smartcardio.CardSimulator;
+import javacard.framework.Applet;
+import javacard.framework.AID;
+
+import javax.smartcardio.CommandAPDU;
+import javax.smartcardio.ResponseAPDU;
+
+public class SimulatorCard extends Card{
+
+    AID aid;
+    CardSimulator card;
+
+
+    public SimulatorCard(AID aid, Class<? extends Applet> appletClass) {
+        this.aid = aid;
+        card = new CardSimulator();
+        card.installApplet(aid, appletClass);
+    }
+
+    @Override
+    public void connect() {
+        card.selectApplet(aid);
+    }
+
+    @Override
+    public void disconnect() {
+        card.reset();
+    }
+
+    public ResponseAPDU transmit(CommandAPDU apdu) {
+        return card.transmitCommand(apdu);
+    }
+}


### PR DESCRIPTION
This PR introduces simple wrappers around jcardsim and smartcardio with unified interface. It allows using these abstractions for running tests on simulator and physical cards.

Everything seems working! Except there was an issue with javacard Exceptions. On my ring all javacard exceptions are converted into `0x6000` regardless of the error code. Only `ISOException` returns the code it contains. So, for now use it for tests. All exceptions will be revised anyway.