### PR TITLE
KEX - key exchange

### DIFF
--- a/applet/build.gradle
+++ b/applet/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.1.1'
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.70'
     testImplementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
+    testImplementation 'at.favre.lib:hkdf:1.1.0'
 
 
     testImplementation(group: 'com.klinec', name: 'javacard-tools', version: '1.0.4') {

--- a/applet/src/main/java/applet/crypto/KEX.java
+++ b/applet/src/main/java/applet/crypto/KEX.java
@@ -56,7 +56,8 @@ import javacard.security.MessageDigest;
 //    split into the auth keys.
 //
 //    contextHash = SHA512("ConfirmationKeys" || context)
-//    authKeyA || authKeyB = HKDF(authKeyMaterial, salt='', info=contextHash, outLength=32)
+//    salt = fromHex("6f6d6e692d72696e67")
+//    authKeyA || authKeyB = HKDF(authKeyMaterial, salt=salt, info=contextHash, outLength=32)
 //
 // 10. Both derive confirmation tags: tagA and tagB using appropriate
 //     authentication keys and transcript. The algorithm is HMAC-SHA256.
@@ -178,8 +179,7 @@ public class KEX {
     private static final byte[] confirmationKeys = { 'C', 'o', 'n', 'f', 'i', 'r', 'm', 'a', 't', 'i', 'o', 'n', 'K',
             'e', 'y', 's' };
 
-    // TODO: come up
-    private static final byte[] hkdfSalt = {};
+    private static final byte[] hkdfSalt = {0x6f, 0x6d, 0x6e, 0x69, 0x2d, 0x72, 0x69, 0x6e, 0x67};
 
     public static void init() {
         buffer = JCSystem.makeTransientByteArray(REQUIRED_BUFFER_LEN, JCSystem.CLEAR_ON_DESELECT);

--- a/applet/src/main/java/applet/crypto/KEX.java
+++ b/applet/src/main/java/applet/crypto/KEX.java
@@ -1,0 +1,329 @@
+package applet.crypto;
+
+import javacard.framework.JCSystem;
+import javacard.framework.Util;
+import javacard.security.CryptoException;
+import javacard.security.MessageDigest;
+
+// Key exchange. This class encapsulates functionality for ECDH key exchange and
+// confirmation with authentication based on pre-shared key.
+//
+// # Design
+// To simplify reading and understanding, the source code and documentation uses
+// the standard conventions of names like Alice and Bob. Alice is a terminal or
+// a client, which speaks to the Bob, which is a card (or in my case ring).
+//
+// The communication requires two rounds: key exchange and key confirmation.
+// This design and implementation are inspired by the SPAKE2[1] algorithm, so
+// KEX shares some similarities, but instead of using complicated password based
+// key exchange, it uses much simpler one based on preshared key.
+//
+// The exchange goes as follows:
+//
+// 1. Alice and Bob have identifiers (aliceID and bobID).
+//
+// 2. Alice and Bob share a pre-shared key (PSK) of sufficient length.
+//
+// 3. Alice generates a P256 keypair and sends her public key (alicePub) to Bob
+//    encoded in SEC1 format.
+//
+// 4. Bob genereates a P256 keypair and sends his public key (bobPub) to Alice
+//    encoded in SEC1 format.
+//
+// 5. Both derive a shared secret with ECDH. Due to the retardness of javacards,
+//    and old firmware on the ring, only SHA1 hash of the shared point is
+//    available, so it's used here instead.
+//
+// 6. Both create a string called a transcript (TT):
+//
+//    TT = len(aliceID)          || aliceId          ||
+//         len(bobID)            || bobID            ||
+//         len(alicePub)         || alicePub         ||
+//         len(bobPub)           || bobPub           ||
+//         len(sha1SharedPoint)  || sha1SharedPoint  ||
+//         len(PSK)              || PSK
+//
+// 7. The transcript is hashed with SHA256 and split into shared secret and
+//    authentication key material:
+//
+//    sharedSecret, authKeyMaterial = SHA256(TT)
+//
+// 8. Alice and Bob also have a context -- a shared piece of data whose
+//    integrity and authenticity can be additionally verified.
+//
+// 9. Both derive two additional keys: authKeyA and authKeyB with HKDF-SHA256.
+//    A SHA512 hash of the context is used as part of info field. The result is
+//    split into the auth keys.
+//
+//    contextHash = SHA512("ConfirmationKeys" || context)
+//    authKeyA || authKeyB = HKDF(authKeyMaterial, salt='', info=contextHash, outLength=32)
+//
+// 10. Both derive confirmation tags: tagA and tagB using appropriate
+//     authentication keys and transcript. The algorithm is HMAC-SHA256.
+//
+//     tagA = HMAC(authKeyA, TT)
+//     tagB = HMAC(authKeyB, TT)
+//
+// 11. Alice sends tagA to Bob.
+// 12. Bob verifies the tagA. If it's correct, Bob sends tagB to Alice.
+// 13. Alice verifies the tagB.
+// 14. If everything is correct, the sharedSecret is used as an output of the
+//     algorithm.
+//
+// Schematically:
+//
+//                     +------------------+       +------------+
+//                     | Alice (Terminal) |       | Bob (Card) |
+//                     +------------------+       +------------+
+//                               |                       |
+//                               | Alice's public key    |
+//                               |---------------------->|
+//                               |                       | -------\
+//                               |                       |-| ECDH |
+//                               |                       | |------|
+//                               |                       |
+//                               |      Bob's public key |
+//                               |<----------------------|
+//                      -------\ |                       |
+//                      | ECDH |-|                       |
+//                      |------| |                       |
+// ----------------------------\ |                       |
+// | Derive confirmation tag A |-|                       |
+// |---------------------------| |                       |
+//                               |                       |
+//                               | confirmation tag A    |
+//                               |---------------------->|
+//                               |                       | ----------------------------\
+//                               |                       |-| Verify confirmation tag A |
+//                               |                       | |---------------------------|
+//                               |                       | ----------------------------\
+//                               |                       |-| Derive confirmation tag B |
+//                               |                       | |---------------------------|
+//                               |                       |
+//                               |    confirmation tag B |
+//                               |<----------------------|
+// ----------------------------\ |                       |
+// | Verify confirmation tag B |-|                       |
+// |---------------------------| |                       |
+//                               |                       |
+//
+// [1]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-spake2/
+//
+// # Usage
+// KEX expects a specific order of call methods though it doesn't validate them
+// internally. Instead, the class relies on a user to keep the track of the
+// state and call appropriate methods without messing everything up. From this
+// perspective, the class can be seend as a set of utilities for integrating
+// into the higher system.
+//
+// The order of calls is as follows:
+//
+// 1. start - accepts aliceId and BobId. Inits the state.
+// 2. exchange - accepts alicePub and output bobPub.
+// 3. setSharedKey - set preshared key. This should go only after the exchange.
+// 4. appendContext - this method feeds data to the context hash function.
+//    Can be called repeatedly and between any previous methods. It's only
+//    important to stop feeding the context data before the next step.
+// 5. confirm - accepts tagA. If it's correct, outputs tagB.
+// 6. sharedSecret - outputs a shared secret.
+// 7. clean - remove all secrets and reset the state.
+//
+public class KEX {
+    public static final short MAX_TRANSCRIPT_LEN = 256;
+
+    private static final short KEY_LEN = 16;
+    private static final short CONTEXT_HASH_LEN = 64;
+    public static final short TAG_SIZE = HmacSha256.HMAC_SIZE;
+
+    public static final short REQUIRED_BUFFER_LEN = (short) (MAX_TRANSCRIPT_LEN
+            + KEY_LEN * 4
+            + CONTEXT_HASH_LEN
+            + TAG_SIZE);
+
+    // buffer consists of
+    // - transcript (256 bytes)
+    // - shared secret (16 bytes)
+    // - auth key material (16 bytes)
+    // - auth key A (16 bytes)
+    // - auth key B (16 bytes)
+    // - context hash (64 bytes)
+    // - tag buffer (32 bytes)
+    //
+    private static byte[] buffer;
+    private static short transcriptOffset;
+    private static short bufferStart;
+    private static short transcriptCapacity;
+    // TODO: this variable changes a lot, move it to the ram
+    private static short transcriptLen;
+
+    private static short sharedPointHashOffset;
+
+    private static short sharedSecretOffset;
+    private static short authKmOffset;
+    private static short authKeyAOffset;
+    private static short authKeyBOffset;
+    private static short contextHashOffset;
+    private static short tagOffset;
+
+    public static final short DATA_TOO_BIG = 0x2929;
+    public static final short TRANSCRIPT_OVERFLOW = 0x7923;
+    public static final short CRYPTO_ERROR = (short) 0xfe97;
+
+    private static MessageDigest sha256;
+    private static MessageDigest contextCollector;
+
+    private static final byte[] confirmationKeys = { 'C', 'o', 'n', 'f', 'i', 'r', 'm', 'a', 't', 'i', 'o', 'n', 'K',
+            'e', 'y', 's' };
+
+    // TODO: come up
+    private static final byte[] hkdfSalt = {};
+
+    public static void init() {
+        buffer = JCSystem.makeTransientByteArray(REQUIRED_BUFFER_LEN, JCSystem.CLEAR_ON_DESELECT);
+
+        bufferStart = 0;
+
+        transcriptOffset = bufferStart;
+        transcriptCapacity = MAX_TRANSCRIPT_LEN;
+        transcriptLen = 0;
+
+        // Shared point will be placed temporarily to copy it to the transcript
+        // We will reuse that place for shared secret key
+        sharedPointHashOffset = MAX_TRANSCRIPT_LEN;
+        sharedSecretOffset = MAX_TRANSCRIPT_LEN;
+
+        authKmOffset = (short) (sharedSecretOffset + KEY_LEN);
+        authKeyAOffset = (short) (authKmOffset + KEY_LEN);
+        authKeyBOffset = (short) (authKeyAOffset + KEY_LEN);
+        contextHashOffset = (short) (authKeyBOffset + KEY_LEN);
+        tagOffset = (short) (contextHashOffset + CONTEXT_HASH_LEN);
+
+        sha256 = MessageDigest.getInstance(
+                MessageDigest.ALG_SHA_256,
+                false // externalAccess
+        );
+
+        contextCollector = MessageDigest.getInstance(
+                MessageDigest.ALG_SHA_512,
+                false // externalAccess
+        );
+    }
+
+    private static void appendTranscript(byte[] data, short offset, short len) {
+        // Just as debug assertion
+        if (len > 127) {
+            CryptoException.throwIt(DATA_TOO_BIG);
+        }
+
+        if ((short) (transcriptLen + len + 1) >= transcriptCapacity) {
+            CryptoException.throwIt(TRANSCRIPT_OVERFLOW);
+        }
+
+        short transcriptEnd = (short) (transcriptOffset + transcriptLen);
+
+        buffer[transcriptEnd] = (byte) len;
+        transcriptEnd++;
+
+        Util.arrayCopyNonAtomic(
+                data, offset, // src
+                buffer, transcriptEnd, // dest
+                len);
+
+        transcriptLen += len + 1;
+    }
+
+    public static void appendContext(byte[] data, short offset, short len) {
+        contextCollector.update(data, offset, len);
+    }
+
+    public static void start(byte[] alice, short aliceOffset, short aliceLen, byte[] bob, short bobOffset,
+            short bobLen) {
+        appendTranscript(alice, aliceOffset, aliceLen);
+        appendTranscript(bob, bobOffset, bobLen);
+
+        contextCollector.reset();
+        appendContext(confirmationKeys, (short) 0, (short) confirmationKeys.length);
+    }
+
+    public static short exchange(byte[] alicePub, short alicePubOffset, short alicePubLen, byte[] outBobPub,
+            short outBobOffset) {
+        appendTranscript(alicePub, alicePubOffset, alicePubLen);
+
+        P256.generateNewKeypair();
+        short sharedPointHashLen = P256.ecdh(alicePub, alicePubOffset, alicePubLen, buffer, sharedPointHashOffset);
+
+        short bobLen = P256.publicKey(outBobPub, outBobOffset);
+        appendTranscript(outBobPub, outBobOffset, bobLen);
+        appendTranscript(buffer, sharedPointHashOffset, sharedPointHashLen);
+
+        Util.arrayFillNonAtomic(buffer, sharedPointHashOffset, sharedPointHashLen, (byte) 0x00);
+
+        return bobLen;
+    }
+
+    public static void setPresharedKey(byte[] key, short offset, short len) {
+        appendTranscript(key, offset, len);
+    }
+
+    public static short confirm(byte[] aliceTag, short aliceTagOffset, short aliceTagLen, byte[] out, short outOffset) {
+        if (aliceTagLen != TAG_SIZE) {
+            CryptoException.throwIt(CRYPTO_ERROR);
+        }
+
+        // Finish context calculation
+        contextCollector.doFinal(confirmationKeys, (short) 0, (short) 0, // empty string
+                buffer, contextHashOffset); // dst
+        contextCollector.reset();
+
+        // Derive shared secret and auth key material
+        sha256.reset();
+        sha256.doFinal(buffer, transcriptOffset, transcriptLen,
+                buffer, sharedSecretOffset);
+        sha256.reset();
+
+        // Derive both authentication keys
+        HKDF.startExtract(hkdfSalt, (short) 0, (short) hkdfSalt.length);
+        HKDF.extractUpdate(buffer, authKmOffset, KEY_LEN);
+        HKDF.extractFinish();
+
+        HKDF.expand(buffer, contextHashOffset, CONTEXT_HASH_LEN, // info
+                buffer, authKeyAOffset, (short) (KEY_LEN + KEY_LEN) // dest, it will fill both keys: A and B
+        );
+
+        HKDF.clean();
+
+        // Derive tag A
+        HmacSha256.start(buffer, authKeyAOffset, KEY_LEN);
+        HmacSha256.update(buffer, transcriptOffset, transcriptLen);
+        HmacSha256.finalize(buffer, tagOffset);
+        HmacSha256.clean();
+
+        if (!Utils.const_eq(buffer, tagOffset, aliceTag, aliceTagOffset, TAG_SIZE)) {
+            CryptoException.throwIt(CRYPTO_ERROR);
+        }
+
+        // Derive tag B
+        HmacSha256.start(buffer, authKeyBOffset, KEY_LEN);
+        HmacSha256.update(buffer, transcriptOffset, transcriptLen);
+        HmacSha256.finalize(out, outOffset);
+        HmacSha256.clean();
+
+        return TAG_SIZE;
+    }
+
+    public static short sharedSecret(byte[] out, short offset) {
+        Util.arrayCopyNonAtomic(
+                buffer, sharedSecretOffset,
+                out, offset,
+                KEY_LEN);
+        clean();
+        return KEY_LEN;
+    }
+
+    public static void clean() {
+        sha256.reset();
+        contextCollector.reset();
+        Util.arrayFillNonAtomic(buffer, bufferStart, REQUIRED_BUFFER_LEN, (byte) 0x00);
+        transcriptLen = 0;
+    }
+}

--- a/applet/src/main/java/common/Utils.java
+++ b/applet/src/main/java/common/Utils.java
@@ -1,5 +1,7 @@
 package common;
 
+import java.util.Arrays;
+
 public class Utils {
     public static byte[] parseHex(String s) {
         final int len = s.length();
@@ -41,5 +43,12 @@ public class Utils {
             r.append(hexCode[(b & 0xF)]);
         }
         return r.toString();
+    }
+
+    // Java, seriously???
+    public static byte[] concat(byte[] first, byte[] second) {
+        byte[] result = Arrays.copyOf(first, first.length + second.length);
+        System.arraycopy(second, 0, result, first.length, second.length);
+        return result;
     }
 }

--- a/applet/src/test/java/tests/KEXTest.java
+++ b/applet/src/test/java/tests/KEXTest.java
@@ -1,0 +1,223 @@
+package tests;
+
+import applet.crypto.CryptoApplet;
+import at.favre.lib.crypto.HKDF;
+import common.Utils;
+import org.bouncycastle.asn1.x9.X9ECParameters;
+import org.bouncycastle.crypto.ec.CustomNamedCurves;
+import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey;
+import org.bouncycastle.jce.interfaces.ECPublicKey;
+import org.bouncycastle.jce.spec.ECParameterSpec;
+import org.bouncycastle.jce.spec.ECPublicKeySpec;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.KeyAgreement;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import javax.smartcardio.CommandAPDU;
+import javax.smartcardio.ResponseAPDU;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.*;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
+
+public class KEXTest extends CryptoBase {
+    public static final int SW_UNKNOWN = 0x6f00;
+
+    ResponseAPDU start(byte[] aliceId, byte[] bobId) throws Exception {
+        Assert.assertEquals(aliceId.length, 16);
+        Assert.assertEquals(bobId.length, 16);
+        CommandAPDU apdu = new CommandAPDU(0x00, CryptoApplet.INS_KEX_START, 0x00, 0x00, Utils.concat(aliceId, bobId));
+        ResponseAPDU res = card.transmit(apdu);
+        Assert.assertEquals(Integer.toHexString(SW_SUCCESS), Integer.toHexString(res.getSW()));
+        return res;
+    }
+
+    ResponseAPDU exchange(byte[] alicePub) throws Exception {
+        CommandAPDU apdu = new CommandAPDU(0x00, CryptoApplet.INS_KEX_EXCHANGE, 0x00, 0x00, alicePub);
+        ResponseAPDU res = card.transmit(apdu);
+        Assert.assertEquals(Integer.toHexString(SW_SUCCESS), Integer.toHexString(res.getSW()));
+        return res;
+    }
+
+    ResponseAPDU setPresharedKey(byte[] key) throws Exception {
+        CommandAPDU apdu = new CommandAPDU(0x00, CryptoApplet.INS_KEX_SET_PRESHARED_KEY, 0x00, 0x00, key);
+        ResponseAPDU res = card.transmit(apdu);
+        Assert.assertEquals(Integer.toHexString(SW_SUCCESS), Integer.toHexString(res.getSW()));
+        return res;
+    }
+
+    ResponseAPDU appendContext(byte[] data) throws Exception {
+        CommandAPDU apdu = new CommandAPDU(0x00, CryptoApplet.INS_KEX_APPEND_CONTEXT, 0x00, 0x00, data);
+        ResponseAPDU res = card.transmit(apdu);
+        Assert.assertEquals(Integer.toHexString(SW_SUCCESS), Integer.toHexString(res.getSW()));
+        return res;
+    }
+
+    ResponseAPDU confirm(byte[] tag) throws Exception {
+        CommandAPDU apdu = new CommandAPDU(0x00, CryptoApplet.INS_KEX_CONFIRM, 0x00, 0x00, tag);
+        ResponseAPDU res = card.transmit(apdu);
+        Assert.assertEquals(Integer.toHexString(SW_SUCCESS), Integer.toHexString(res.getSW()));
+        return res;
+    }
+
+    ResponseAPDU sharedSecret() throws Exception {
+        CommandAPDU apdu = new CommandAPDU(0x00, CryptoApplet.INS_KEX_SHARED_SECRET, 0x00, 0x00, new byte[] {});
+        ResponseAPDU res = card.transmit(apdu);
+        Assert.assertEquals(Integer.toHexString(SW_SUCCESS), Integer.toHexString(res.getSW()));
+        return res;
+    }
+
+    ResponseAPDU clean() throws Exception {
+        CommandAPDU apdu = new CommandAPDU(0x00, CryptoApplet.INS_KEX_CLEAN, 0x00, 0x00, new byte[] {});
+        ResponseAPDU res = card.transmit(apdu);
+        Assert.assertEquals(Integer.toHexString(SW_SUCCESS), Integer.toHexString(res.getSW()));
+        return res;
+    }
+
+    public static ECPublicKey loadPublicKey(byte[] data)
+            throws InvalidKeySpecException, NoSuchAlgorithmException, NoSuchProviderException {
+        ECParameterSpec ecParameterSpec = getParameterSpec();
+        ECPublicKeySpec publicKey = new ECPublicKeySpec(ecParameterSpec.getCurve().decodePoint(data), ecParameterSpec);
+        KeyFactory kf = KeyFactory.getInstance("ECDH", "BC");
+        return (ECPublicKey) kf.generatePublic(publicKey);
+    }
+
+    public static KeyPair newKeyPair() throws Exception {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ECDH", "BC");
+        ECParameterSpec ecSpec = getParameterSpec();
+        keyGen.initialize(ecSpec, new SecureRandom());
+        return keyGen.generateKeyPair();
+    }
+
+    public static byte[] encodePublic(KeyPair pair) {
+        return ((BCECPublicKey) pair.getPublic()).getQ().getEncoded(false);
+    }
+
+    public static byte[] javacardECDH(KeyPair alice, ECPublicKey bob) throws Exception {
+        KeyAgreement agree = KeyAgreement.getInstance("ECDH", "BC");
+        agree.init(alice.getPrivate());
+        agree.doPhase(bob, true);
+
+        MessageDigest hash = MessageDigest.getInstance("SHA1", "BC");
+        return hash.digest(agree.generateSecret());
+    }
+
+    public static byte[] getContextHash(byte[] context) throws NoSuchAlgorithmException, NoSuchProviderException {
+        MessageDigest hash = MessageDigest.getInstance("SHA512", "BC");
+        hash.update("ConfirmationKeys".getBytes());
+        hash.update(context);
+        return hash.digest();
+    }
+
+    static Keys deriveKeys(byte[] transcript, byte[] salt, byte[] contextHash) throws Exception {
+        byte[] keys = MessageDigest.getInstance("SHA256", "BC").digest(transcript);
+        byte[] sharedSecret = Arrays.copyOfRange(keys, 0, 16);
+        byte[] authKeyMaterial = Arrays.copyOfRange(keys, 16, 32);
+
+        byte[] prf = HKDF.fromHmacSha256().extract(salt, authKeyMaterial);
+        byte[] authKeys = HKDF.fromHmacSha256().expand(prf, contextHash, 32);
+        byte[] authKeyA = Arrays.copyOfRange(authKeys, 0, 16);
+        byte[] authKeyB = Arrays.copyOfRange(authKeys, 16, 32);
+        return new Keys(sharedSecret, authKeyA, authKeyB);
+    }
+
+    @Test
+    void basicUsage() throws Exception {
+        byte[] aliceId = Utils.parseHex("f87165e305b0f7c4824d3806434f9d09");
+        byte[] bobId = Utils.parseHex("1a1707bb54e5fb4deddd19f07adcb4f1");
+        byte[] context = Utils.parseHex("d180d183d181d0bdd19620d0bfd196d0b7d0b4d0b0");
+        byte[] presharedKey = Utils.parseHex("9060c103d4f27cd1ac4d3c6eb0a979db41f86003b0fffa32c6f96813aba55737");
+        byte[] salt = Utils.parseHex("");
+
+        KeyPair alice = newKeyPair();
+        byte[] alicePub = encodePublic(alice);
+
+        TranscriptBuilder transcriptBuilder = new TranscriptBuilder()
+                .append(aliceId)
+                .append(bobId)
+                .append(alicePub);
+
+        start(aliceId, bobId);
+
+        ResponseAPDU exchangeResponse = exchange(alicePub);
+
+        transcriptBuilder.append(exchangeResponse.getData());
+        ECPublicKey bobPub = loadPublicKey(exchangeResponse.getData());
+
+        byte[] sharedPointHash = javacardECDH(alice, bobPub);
+        transcriptBuilder
+                .append(sharedPointHash)
+                .append(presharedKey);
+
+        byte[] transcript = transcriptBuilder.build();
+        byte[] contextHash = getContextHash(context);
+
+        setPresharedKey(presharedKey);
+        appendContext(context);
+
+        Keys keys = deriveKeys(transcript, salt, contextHash);
+        byte[] tagA = hmacSha256(keys.authKeyA, transcript);
+
+        byte[] tagBExpected = hmacSha256(keys.authKeyB, transcript);
+        byte[] tagBReceived = confirm(tagA).getData();
+
+        // NOTE: this operation is UNSAFE. Comparing secrets should be in constant time
+        // manner
+        Assertions.assertEquals(Utils.toHex(tagBExpected), Utils.toHex(tagBReceived));
+
+        byte[] sharedSecretReceived = sharedSecret().getData();
+        Assertions.assertEquals(Utils.toHex(keys.sharedSecret), Utils.toHex(sharedSecretReceived));
+
+        clean();
+    }
+
+    public static byte[] hmacSha256(byte[] key, byte[] data) throws NoSuchAlgorithmException, InvalidKeyException {
+        final String ALGORITHM = "HmacSHA256";
+        Mac hmacSha256 = Mac.getInstance(ALGORITHM);
+        SecretKeySpec secretKey = new SecretKeySpec(key, ALGORITHM);
+        hmacSha256.init(secretKey);
+        return hmacSha256.doFinal(data);
+    }
+
+    @NotNull
+    public static ECParameterSpec getParameterSpec() {
+        X9ECParameters params = CustomNamedCurves.getByName("secp256r1");
+        ECParameterSpec ecParameterSpec = new ECParameterSpec(params.getCurve(), params.getG(), params.getN(),
+                params.getH(), params.getSeed());
+        return ecParameterSpec;
+    }
+}
+
+class Keys {
+    byte[] sharedSecret;
+    byte[] authKeyA;
+    byte[] authKeyB;
+
+    public Keys(byte[] sharedSecret, byte[] authKeyA, byte[] authKeyB) {
+        this.sharedSecret = sharedSecret;
+        this.authKeyA = authKeyA;
+        this.authKeyB = authKeyB;
+    }
+}
+
+class TranscriptBuilder {
+    ByteArrayOutputStream transcript = new ByteArrayOutputStream();
+
+    TranscriptBuilder append(byte[] chunk) throws IOException {
+        byte len = (byte) chunk.length;
+
+        transcript.write(len);
+        transcript.write(chunk);
+
+        return this;
+    }
+
+    byte[] build() {
+        return transcript.toByteArray();
+    }
+}

--- a/applet/src/test/java/tests/KEXTest.java
+++ b/applet/src/test/java/tests/KEXTest.java
@@ -131,7 +131,7 @@ public class KEXTest extends CryptoBase {
         byte[] bobId = Utils.parseHex("1a1707bb54e5fb4deddd19f07adcb4f1");
         byte[] context = Utils.parseHex("d180d183d181d0bdd19620d0bfd196d0b7d0b4d0b0");
         byte[] presharedKey = Utils.parseHex("9060c103d4f27cd1ac4d3c6eb0a979db41f86003b0fffa32c6f96813aba55737");
-        byte[] salt = Utils.parseHex("");
+        byte[] salt = Utils.parseHex("6f6d6e692d72696e67");
 
         KeyPair alice = newKeyPair();
         byte[] alicePub = encodePublic(alice);
@@ -184,7 +184,7 @@ public class KEXTest extends CryptoBase {
         byte[] context = Utils.parseHex("d180d183d181d0bdd19620d0bfd196d0b7d0b4d0b0");
         byte[] presharedKeyAlice = Utils.parseHex("9060c103d4f27cd1ac4d3c6eb0a979db41f86003b0fffa32c6f96813aba55737");
         byte[] presharedKeyBob = Utils.parseHex("9060c103d3f27cd1ac4d3c6eb0a979db41f86003b0fffa32c6f96813aba55737");
-        byte[] salt = Utils.parseHex("");
+        byte[] salt = Utils.parseHex("6f6d6e692d72696e67");
 
         KeyPair alice = newKeyPair();
         byte[] alicePub = encodePublic(alice);
@@ -227,7 +227,7 @@ public class KEXTest extends CryptoBase {
         byte[] contextAlice = Utils.parseHex("d180d183d181d0bdd19620d0bfd196d0b7d0b4d0b0");
         byte[] contextBob = Utils.parseHex("d180d183d181d0bdd19620d0bfd196d0b7d0b4d0b000");
         byte[] presharedKey = Utils.parseHex("9060c103d4f27cd1ac4d3c6eb0a979db41f86003b0fffa32c6f96813aba55737");
-        byte[] salt = Utils.parseHex("");
+        byte[] salt = Utils.parseHex("6f6d6e692d72696e67");
 
         KeyPair alice = newKeyPair();
         byte[] alicePub = encodePublic(alice);


### PR DESCRIPTION
This PR introduces a new class KEX. It encapsulates ECDH key-exchange with pre-shared key.

The details can be read in the comments of the source code. I only mention that this specific design with the key confirmation step was inspired by the [SPAKE2](https://datatracker.ietf.org/doc/draft-irtf-cfrg-spake2/) and have a lot of things in common.

This is the last cryptographic building block! The next steps are refactoring some other primitives (AES encryption) and then putting all cryptography together and starting work on the actual secret storage applet.